### PR TITLE
[dunwich] Use directories for persistent docker volumes

### DIFF
--- a/hosts/dunwich/commento.docker-compose.nix
+++ b/hosts/dunwich/commento.docker-compose.nix
@@ -47,12 +47,17 @@
       networks:
         - commento
       volumes:
-        - commento_postgres:/var/lib/postgresql/data
+        - commento_pgdata:/var/lib/postgresql/data
 
   networks:
     commento:
       external: false
 
   volumes:
-    commento_postgres:
+    commento_pgdata:
+      driver: local
+      driver_opts:
+        o: bind,
+        type: none,
+        device: /persist/docker-volumes/commento/pgdata
 ''

--- a/hosts/dunwich/configuration.nix
+++ b/hosts/dunwich/configuration.nix
@@ -251,6 +251,7 @@ in
   services.pleroma.webPushPublicKey = fileContents /etc/nixos/secrets/pleroma/web-push-public-key.txt;
   services.pleroma.webPushPrivateKey = fileContents /etc/nixos/secrets/pleroma/web-push-private-key.txt;
   services.pleroma.execStartPre = "${pullDevDockerImage} pleroma:latest";
+  services.pleroma.dockerVolumeDir = /persist/docker-volumes/pleroma;
 
   # bookdb
   services.bookdb.enable = true;
@@ -258,6 +259,7 @@ in
   services.bookdb.baseURI = "https://bookdb.barrucadu.co.uk";
   services.bookdb.readOnly = true;
   services.bookdb.execStartPre = "${pullDevDockerImage} bookdb:latest";
+  services.bookdb.dockerVolumeDir = /persist/docker-volumes/bookdb;
 
   # bookmarks
   services.bookmarks.enable = true;
@@ -266,11 +268,13 @@ in
   services.bookmarks.readOnly = true;
   services.bookmarks.execStartPre = "${pullDevDockerImage} bookmarks:latest";
   services.bookmarks.httpPort = 3003;
+  services.bookmarks.dockerVolumeDir = /persist/docker-volumes/bookmarks;
 
   # etherpad
   services.etherpad.enable = true;
   services.etherpad.image = "etherpad/etherpad:stable";
   services.etherpad.httpPort = 3006;
+  services.etherpad.dockerVolumeDir = /persist/docker-volumes/etherpad;
 
   # minecraft
   services.minecraft.enable = true;

--- a/hosts/dunwich/umami.docker-compose.nix
+++ b/hosts/dunwich/umami.docker-compose.nix
@@ -32,12 +32,17 @@
       networks:
         - umami
       volumes:
-        - umami_postgres:/var/lib/postgresql/data
+        - umami_pgdata:/var/lib/postgresql/data
 
   networks:
     umami:
       external: false
 
   volumes:
-    umami_postgres:
+    umami_pgdata:
+      driver: local
+      driver_opts:
+        o: bind,
+        type: none,
+        device: /persist/docker-volumes/umami/pgdata
 ''


### PR DESCRIPTION
I ran `docker volume prune` and it deleted a bunch of volumes which
were in use:

- pleroma database (but not emojis or uploads)
- bookdb covers (but not esdata)
- bookmarks esdata
- umami database
- commento database

But all of the services were up and running, and using those volumes!
So somehow despite the volumes being in use, they got deleted.  wtf?