### PR TITLE
Improve concourse monitoring & run worker as "ephemeral" to fix volume leak

### DIFF
--- a/hosts/carcosa/configuration.nix
+++ b/hosts/carcosa/configuration.nix
@@ -11,6 +11,7 @@ let
   umamiPort = 3006;
   pleromaPort = 3007;
   etherpadPort = 3008;
+  concourseMetricsPort = 3009;
 
   pullDevDockerImage = pkgs.writeShellScript "pull-dev-docker-image.sh" ''
     set -e
@@ -325,6 +326,7 @@ in
   # concourse
   services.concourse.enable = true;
   services.concourse.httpPort = concoursePort;
+  services.concourse.metricsPort = concourseMetricsPort;
   services.concourse.githubClientId = fileContents /etc/nixos/secrets/concourse-clientid.txt;
   services.concourse.githubClientSecret = fileContents /etc/nixos/secrets/concourse-clientsecret.txt;
   services.concourse.enableSSM = true;

--- a/hosts/carcosa/configuration.nix
+++ b/hosts/carcosa/configuration.nix
@@ -368,6 +368,13 @@ in
 
   # Metrics
   services.prometheus.webExternalUrl = "https://prometheus.carcosa.barrucadu.co.uk";
+  services.prometheus.scrapeConfigs = [
+    {
+      job_name = "${config.networking.hostName}-concourse";
+      static_configs = [{ targets = [ "localhost:${toString config.services.concourse.metricsPort}" ]; }];
+    }
+  ];
+
   systemd.services.prometheus-statedir = {
     enable = true;
     description = "Bind-mount prometheus StateDirectory";

--- a/services/concourse.nix
+++ b/services/concourse.nix
@@ -17,6 +17,7 @@ in
     enableSSM = mkOption { type = types.bool; default = false; };
     githubUser = mkOption { type = types.str; default = "barrucadu"; };
     httpPort = mkOption { type = types.int; default = 3001; };
+    metricsPort = mkOption { type = types.int; default = 9001; };
     postgresTag = mkOption { type = types.str; default = "13"; };
     ssmAccessKey = mkOption { type = types.nullOr types.str; default = null; };
     ssmRegion = mkOption { type = types.str; default = "eu-west-1"; };

--- a/services/docker-compose-files/concourse.docker-compose.nix
+++ b/services/docker-compose-files/concourse.docker-compose.nix
@@ -48,7 +48,7 @@
 
     worker:
       image: concourse/concourse:${concourseTag}
-      command: worker
+      command: ["worker", "--ephemeral"]
       privileged: true
       restart: always
       environment:

--- a/services/docker-compose-files/concourse.docker-compose.nix
+++ b/services/docker-compose-files/concourse.docker-compose.nix
@@ -5,6 +5,7 @@
 , enableSSM ? false
 , githubUser ? "barrucadu"
 , httpPort ? 3001
+, metricsPort ? 9001
 , postgresTag ? "13"
 , ssmAccessKey ? null
 , ssmRegion ? "eu-west-1"
@@ -32,6 +33,8 @@
         CONCOURSE_GITHUB_CLIENT_SECRET: "${githubClientSecret}"
         CONCOURSE_LOG_LEVEL: error
         CONCOURSE_GARDEN_LOG_LEVEL: error
+        CONCOURSE_PROMETHEUS_BIND_IP: "0.0.0.0"
+        CONCOURSE_PROMETHEUS_BIND_PORT: "8088"
         ${if enableSSM then "CONCOURSE_AWS_SSM_REGION: \"${ssmRegion}\"" else ""}
         ${if enableSSM then "CONCOURSE_AWS_SSM_ACCESS_KEY: \"${ssmAccessKey}\"" else ""}
         ${if enableSSM then "CONCOURSE_AWS_SSM_SECRET_KEY: \"${ssmSecretKey}\"" else ""}
@@ -39,6 +42,7 @@
         - ${toString dockerVolumeDir}/keys/web:/concourse-keys
       ports:
         - "127.0.0.1:${toString httpPort}:8080"
+        - "127.0.0.1:${toString metricsPort}:8088"
       depends_on:
         - db
 


### PR DESCRIPTION
I had to stop using the `quickstart` command when I migrated Concourse to carcosa (2bb1684b482972e95ff11409458f4acde304a5cf), because:

1. Concourse workers don't get on with ZFS (https://github.com/concourse/concourse-docker/issues/42)
2. But that's ok, there's an environment variable to use a different directory
3. But that environment variable only works with the `worker` command, not the `quickstart` command

Unfortunately, there was an unforeseen downside to this change.  When running separate `web` and `worker` processes, a "stalled" worker (which is what happens after, eg, restarting the docker-compose project) doesn't get deleted automatically, and so any volumes which belong to the old worker won't get garbage collected.  Resulting in a disk space leak.

After a few restarts I ended up with 3 stalled workers and 625 volumes, using up a majority of the space on the filesystem I'd dedicated to Concourse.  This wasn't very clear as I don't know much about running Concourse.  So, this PR:

- Enables Prometheus metrics (and gets carcosa scraping those), which made debugging this far easier than my initial strategy of trying to examine `docker` and `fly` output
- Runs the worker with the `--ephemeral` flag, so that a stalled worker gets instantly reaped.