### PR TITLE
Tighten up docker unit dependencies

### DIFF
--- a/common.nix
+++ b/common.nix
@@ -130,6 +130,7 @@ with lib;
       enable = config.services.prometheus.enable;
       description = "Docker exporter for Prometheus";
       after = [ "docker.service" ];
+      bindsTo = [ "docker.service" ];
       wantedBy = [ "prometheus.service" ];
       serviceConfig = {
         Restart = "always";

--- a/hosts/nyarlathotep/configuration.nix
+++ b/hosts/nyarlathotep/configuration.nix
@@ -342,6 +342,7 @@ in
     enable = true;
     description = "Speedtest.net exporter for Prometheus";
     after = [ "docker.service" ];
+    requires = [ "docker.service" ];
     wantedBy = [ "prometheus.service" ];
     serviceConfig.Restart = "always";
     serviceConfig.ExecStartPre = [
@@ -355,6 +356,7 @@ in
     enable = true;
     description = "UniFi Poller exporter for Prometheus";
     after = [ "docker.service" ];
+    requires = [ "docker.service" ];
     wantedBy = [ "prometheus.service" ];
     serviceConfig.Restart = "always";
     serviceConfig.ExecStartPre = [
@@ -368,6 +370,7 @@ in
     enable = true;
     description = "Awair exporter for Prometheus";
     after = [ "docker.service" ];
+    requires = [ "docker.service" ];
     wantedBy = [ "prometheus.service" ];
     serviceConfig.Restart = "always";
     serviceConfig.ExecStartPre = [

--- a/services/snippets/docker-compose-service.nix
+++ b/services/snippets/docker-compose-service.nix
@@ -14,6 +14,7 @@ in
   enable = true;
   wantedBy = [ "multi-user.target" ];
   requires = [ "docker.service" ];
+  after = [ "docker.service" ];
   environment = { COMPOSE_PROJECT_NAME = composeProjectName; };
   serviceConfig = lib.mkMerge [
     (lib.mkIf (execStartPre != null) { ExecStartPre = "${execStartPre}"; })


### PR DESCRIPTION
`After`, `BindsTo`, and `Requires` all do slightly different things:

`After` imposes an ordering constraint.  If unit `X` has `After=Y` and
both `X` and `Y` are started, then `X` will be delayed until `Y` has
finished starting.

So we want `After=docker.service`, as `docker` and `docker-compose`
won't work if the daemon is not up yet.

`BindsTo` and `Requires` impose dependencies.  If a unit `X` has
`BindsTo=Y` or `Requires=Y`, and `X` is started then `Y` will be
started if it not already running.

Combining `Requires=Y` (or `BindsTo=Y`) and `After=Y` means that
starting `X` will

- Start `Y`
- Wait for `Y` to finish starting
- Then start `X`

If there is no `After`, then instead `X` and `Y` will be started in
parallel.

`BindsTo` also makes `X` stop if `Y` stops.  This is particularly
useful for units which bind-mount the docker socket (as the
prometheus-docker-exporter does), as if the docker daemon restarts
then the old socket is invalid.