### PR TITLE
Reduce JVM memory allocations

### DIFF
--- a/services/docker-compose-files/bookdb.docker-compose.nix
+++ b/services/docker-compose-files/bookdb.docker-compose.nix
@@ -32,7 +32,7 @@
       environment:
         - http.host=0.0.0.0
         - discovery.type=single-node
-        - ES_JAVA_OPTS=-Xms1g -Xmx1g
+        - ES_JAVA_OPTS=-Xms512M -Xmx512M
       volumes:
         - ${toString dockerVolumeDir}/esdata:/usr/share/elasticsearch/data
 ''

--- a/services/docker-compose-files/bookmarks.docker-compose.nix
+++ b/services/docker-compose-files/bookmarks.docker-compose.nix
@@ -31,7 +31,7 @@
       environment:
         - http.host=0.0.0.0
         - discovery.type=single-node
-        - ES_JAVA_OPTS=-Xms1g -Xmx1g
+        - ES_JAVA_OPTS=-Xms512M -Xmx512M
       volumes:
         - ${toString dockerVolumeDir}/esdata:/usr/share/elasticsearch/data
 ''

--- a/services/docker-compose-files/finder.docker-compose.nix
+++ b/services/docker-compose-files/finder.docker-compose.nix
@@ -29,7 +29,7 @@
       environment:
         - http.host=0.0.0.0
         - discovery.type=single-node
-        - ES_JAVA_OPTS=-Xms1g -Xmx1g
+        - ES_JAVA_OPTS=-Xms512M -Xmx512M
       volumes:
         - ${toString dockerVolumeDir}/esdata:/usr/share/elasticsearch/data
 ''

--- a/services/minecraft.nix
+++ b/services/minecraft.nix
@@ -13,7 +13,7 @@ in
     port = mkOption { type = types.int; default = 25565; };
     dataDir = mkOption { type = types.path; default = "/srv/minecraft"; };
     jar = mkOption { type = types.str; default = "fabric-server-launch.jar"; };
-    jvmOpts = mkOption { type = types.separatedString " "; default = "-Xmx6144M -Xms6144M"; };
+    jvmOpts = mkOption { type = types.separatedString " "; default = "-Xmx4096M -Xms4096M"; };
   };
 
   config = mkIf cfg.enable {


### PR DESCRIPTION
I gave quite generous memory allocations to Minecraft, bookdb, bookmarks, and finder.  But looking at the actual usage, there's no need to reserve so much.  This change gives carcosa a nice amount of headroom for future developments.