### PR TITLE
Specify 21.05 as the auto-upgrade channel

### DIFF
--- a/common.nix
+++ b/common.nix
@@ -32,7 +32,7 @@ with lib;
     # Upgrade packages and reboot if needed
     system.autoUpgrade.enable = true;
     system.autoUpgrade.allowReboot = true;
-    system.autoUpgrade.channel = https://nixos.org/channels/nixos-20.09;
+    system.autoUpgrade.channel = https://nixos.org/channels/nixos-21.05;
     system.autoUpgrade.dates = "06:45";
 
     #############################################################################


### PR DESCRIPTION
I've spent a good chunk of time today wondering "hmm, why have all my
servers auto-downgraded themselves overnight?"