### PR TITLE
Use headless JRE 8 for minecraft

### DIFF
--- a/services/minecraft.nix
+++ b/services/minecraft.nix
@@ -31,7 +31,7 @@ in
       after = [ "network.target" ];
 
       serviceConfig = {
-        ExecStart = "${pkgs.jre}/bin/java ${cfg.jvmOpts} -jar ${cfg.jar}";
+        ExecStart = "${pkgs.jre8_headless}/bin/java ${cfg.jvmOpts} -jar ${cfg.jar}";
         Restart = "always";
         User = "minecraft";
         WorkingDirectory = cfg.dataDir;


### PR DESCRIPTION
Missed in the 21.05 upgrade notes:

> jre now defaults to GTK UI by default. This improves visual
> consistency and makes Java follow system font style, improving the
> situation on HighDPI displays. This has a cost of increased closure
> size; for server and other headless workloads it's recommended to
> use jre_headless.

Also, the Minecraft server I currently have assumes Java 8 and crashes
when run with a later version.  So much for the legendary backwards
compatibility of Java.