### PR TITLE
Delete old generations automatically

### DIFF
--- a/common.nix
+++ b/common.nix
@@ -16,6 +16,7 @@ with lib;
 
     # Collect nix store garbage and optimise daily.
     nix.gc.automatic = true;
+    nix.gc.options = "--delete-older-than 30d";
     nix.optimise.automatic = true;
 
     # Clear out /tmp after a fortnight and give all normal users a ~/tmp


### PR DESCRIPTION
I wondered why /boot had filled up on nyarlathotep despite the daily
GC, only to then realise that old generations weren't being collected.

I don't want to remove all old generations, as then if there's some
problem which results in an unbootable system, I'd need to use a
liveUSB (or boot from an ISO, for remote machines) to get in.
Deleting generations older than a month feels like a good compromise
between safety and space: since I have automatic reboots for updates,
it doesn't feel very likely to not notice a machine is unbootable in
that time.