### PR TITLE
Fix Concourse cgroup issue

### DIFF
--- a/services/concourse.nix
+++ b/services/concourse.nix
@@ -26,6 +26,9 @@ in
   };
 
   config = mkIf cfg.enable {
+    # https://github.com/concourse/concourse/discussions/6529
+    boot.kernelParams = [ "systemd.unified_cgroup_hierarchy=0" ];
+
     systemd.services.concourse = import ./snippets/docker-compose-service.nix {
       inherit lib pkgs yaml;
       composeProjectName = "concourse";


### PR DESCRIPTION
After a recent reboot, Concourse stopped working.  The culprit seems
to be a cgroup issue as described in the linked GitHub issue (see
diff), so it's likely a systemd or kernel upgrade which broke it.

Since everything else is otherwise working fine, this is better than
rolling back to an older generation.