### PR TITLE
Upgrade Concourse to 7.4

### DIFF
--- a/services/docker-compose-files/concourse.docker-compose.nix
+++ b/services/docker-compose-files/concourse.docker-compose.nix
@@ -1,7 +1,7 @@
 { dockerVolumeDir
 , githubClientId
 , githubClientSecret
-, concourseTag ? "7.1"
+, concourseTag ? "7.4"
 , enableSSM ? false
 , githubUser ? "barrucadu"
 , httpPort ? 3001
@@ -53,6 +53,8 @@
       restart: always
       environment:
         CONCOURSE_TSA_HOST: web:2222
+        CONCOURSE_CONTAINERD_DNS_PROXY_ENABLE: "false"
+        CONCOURSE_GARDEN_DNS_SERVER: "1.1.1.1,8.8.8.8"
         ${if workerScratchDir == null then "" else "CONCOURSE_WORK_DIR: \"/workdir\""}
       volumes:
         - ${toString dockerVolumeDir}/keys/worker:/concourse-keys


### PR DESCRIPTION
Unfortunately, there's a DNS resolution issue with this: sometimes,
when using the default resolver (which I believe comes from docker, as
it's on a 172 IP), names fail to resolve, which generally makes a job
fail.

So, skip the local DNS resolution entirely and use 1.1.1.1, falling
back to 8.8.8.8 if it's down.  So far this looks to solve the issue.