### PR TITLE
[carcosa] Use PHP 7.4 for uzbl.org

### DIFF
--- a/hosts/carcosa/configuration.nix
+++ b/hosts/carcosa/configuration.nix
@@ -273,6 +273,7 @@ in
   '';
 
   services.phpfpm.pools.caddy = {
+    phpPackage = pkgs.php74;
     user = "caddy";
     group = "caddy";
     settings = {


### PR DESCRIPTION
NixOS 21.11 changed the default PHP version to 8, which the old
uzbl.org code does not support.