### PR TITLE
Add firewall module with fail2ban and ip blocking

### DIFF
--- a/common.nix
+++ b/common.nix
@@ -61,9 +61,6 @@ in
     ## Services
     #############################################################################
 
-    # Ping is enabled
-    networking.firewall.allowPing = true;
-
     # Every machine gets an sshd
     services.openssh = {
       enable = true;

--- a/configuration.nix
+++ b/configuration.nix
@@ -5,6 +5,7 @@
     ./host/hardware.nix
     ./modules/backup-scripts.nix
     ./modules/erase-your-darlings.nix
+    ./modules/firewall.nix
     ./modules/monitoring-scripts.nix
     ./modules/zfs-automation.nix
     ./services/bookdb.nix

--- a/hosts/azathoth/configuration.nix
+++ b/hosts/azathoth/configuration.nix
@@ -26,8 +26,7 @@ in
   hardware.pulseaudio.support32Bit = true;
 
   # Firewall
-  networking.firewall.enable = true;
-  networking.firewall.trustedInterfaces = [ "lo" "enp6s0" ];
+  networking.firewall.trustedInterfaces = [ "enp6s0" ];
 
   # Nyarlathotep
   fileSystems."/home/barrucadu/nfs/anime" = nfsShare "anime";

--- a/hosts/carcosa/configuration.nix
+++ b/hosts/carcosa/configuration.nix
@@ -40,9 +40,7 @@ in
   modules.zfsAutomation.enable = true;
 
   # Networking
-  networking.firewall.enable = true;
   networking.firewall.allowedTCPPorts = [ 80 222 443 ];
-  networking.firewall.trustedInterfaces = [ "lo" "docker0" ];
 
   networking.interfaces.enp1s0 = {
     ipv6.addresses = [{ address = "2a01:4f8:c0c:bfc1::"; prefixLength = 64; }];

--- a/hosts/carcosa/configuration.nix
+++ b/hosts/carcosa/configuration.nix
@@ -47,6 +47,8 @@ in
   };
   networking.defaultGateway6 = { address = "fe80::1"; interface = "enp1s0"; };
 
+  modules.firewall.ipBlocklist = import /etc/nixos/secrets/ip-blocklist.nix;
+
   # No automatic reboots (for irssi)
   system.autoUpgrade.allowReboot = mkForce false;
 

--- a/hosts/lainonlife/configuration.nix
+++ b/hosts/lainonlife/configuration.nix
@@ -71,8 +71,6 @@ in
 
   # Firewall
   networking.firewall.allowedTCPPorts = [ 80 443 8000 ];
-  networking.firewall.allowedTCPPortRanges = [{ from = 62001; to = 63000; }];
-  networking.firewall.allowedUDPPortRanges = [{ from = 62001; to = 63000; }];
 
   # Web server
   services.caddy.enable = true;

--- a/hosts/nyarlathotep/configuration.nix
+++ b/hosts/nyarlathotep/configuration.nix
@@ -32,8 +32,7 @@ in
   modules.zfsAutomation.enable = true;
 
   # Firewall
-  networking.firewall.enable = true;
-  networking.firewall.trustedInterfaces = [ "lo" "docker0" "enp4s0" ];
+  networking.firewall.trustedInterfaces = [ "enp4s0" ];
   networking.firewall.allowedTCPPorts = [ 8888 ]; # for testing stuff
 
   # Wipe / on boot

--- a/modules/firewall.nix
+++ b/modules/firewall.nix
@@ -1,0 +1,40 @@
+{ config, lib, ... }:
+
+with lib;
+
+let
+  cfg = config.modules.firewall;
+in
+{
+  options = {
+    modules = {
+      firewall = {
+        enable = mkOption { type = types.bool; default = true; };
+        ipBlocklist = mkOption { type = types.listOf types.str; default = [ ]; };
+      };
+    };
+  };
+
+  config = mkIf cfg.enable {
+    networking.firewall.enable = true;
+    networking.firewall.allowPing = true;
+    networking.firewall.trustedInterfaces = if config.virtualisation.docker.enable then [ "docker0" ] else [ ];
+
+    services.fail2ban.enable = true;
+
+    networking.firewall.extraCommands = ''
+      iptables -N barrucadu-ip-blocklist
+      ${concatMapStringsSep "\n" (ip: "iptables -A barrucadu-ip-blocklist -s ${ip} -j DROP") cfg.ipBlocklist}
+      iptables -A barrucadu-ip-blocklist -j RETURN
+      iptables -A INPUT -j barrucadu-ip-blocklist
+    '';
+
+    networking.firewall.extraStopCommands = ''
+      if iptables -n --list barrucadu-ip-blocklist &>/dev/null; then
+        iptables -D INPUT -j barrucadu-ip-blocklist
+        iptables -F barrucadu-ip-blocklist
+        iptables -X barrucadu-ip-blocklist
+      fi
+    '';
+  };
+}


### PR DESCRIPTION
There are a lot of connection attempts to my whitelisted Minecraft
server.  I occasionally check the Minecraft logs, and it's kind of
annoying having to mentally filter through these.  Since they come
from a handful of IPs, it's nice to have a way to block them.

This is done with a new iptables chain, put before the nixos-fw chain,
which just either drops a connection if it's on the naughty list, or
returns to the INPUT chain.

I only really need this on carcosa, because that's where the affected
service is, but there's no reason not to make this a module which all
hosts pull in.

And, since I'm adding one sort of blocking, I thought I may as well
also turn on fail2ban, which will (by default) block SSH connection
attempts.