### PR TITLE
[nyarlathotep] Remove implicit dependency on collectd / xen

### DIFF
--- a/hosts/nyarlathotep/configuration.nix
+++ b/hosts/nyarlathotep/configuration.nix
@@ -410,6 +410,8 @@ in
   ###############################################################################
 
   services.influxdb.enable = true;
+  # override collectd config to not pull in the collectd-data package
+  services.influxdb.extraConfig = { collectd = [{ enabled = false; }]; };
 
   systemd.timers.hledger-scripts = {
     wantedBy = [ "timers.target" ];


### PR DESCRIPTION
nixpkgs recently marked old versions of xen as insecure, requiring an
override to be put in place in your config to install them.  I started
getting this error.

But that's weird, I don't use xen:

    $ nixos-option virtualisation.xen.enable
    Value:
    false

I found (through `nix-store --query`) that collectd was pulling it
in (via its xencpu plugin[1]).  But I don't use collectd:

    $ nixos-option services.collectd.enable
    Value:
    false

Digging into the dependencies a little deeper, I found that the
influxdb config file references the collectd-data package[2], which in
turn depends on collectd.

So even though influxdb doesn't enable its collectd plugin by default,
it does still force the package to be installed (which in turn forces
the insecure version of xen to be installed) because of that
reference.

The solution is to totally override the influxdb-collectd config to
not reference the package at all.  Even better would be to remove it
entirely, but I don't think that's doable with the interface nixpkgs
provides.

[1] https://github.com/NixOS/nixpkgs/blob/6c4b9f1a2fd761e2d384ef86cff0d208ca27fdca/pkgs/tools/system/collectd/plugins.nix
[2] https://github.com/NixOS/nixpkgs/blob/6c4b9f1a2fd761e2d384ef86cff0d208ca27fdca/nixos/modules/services/databases/influxdb.nix#L69