### PR TITLE
Upgrade services to elasticsearch 7.17.0

### DIFF
--- a/services/bookdb.nix
+++ b/services/bookdb.nix
@@ -13,7 +13,7 @@ in
     enable = mkOption { type = types.bool; default = false; };
     image = mkOption { type = types.str; };
     httpPort = mkOption { type = types.int; default = 3000; };
-    esTag = mkOption { type = types.str; default = "7.11.2"; };
+    esTag = mkOption { type = types.str; default = "7.17.0"; };
     baseURI = mkOption { type = types.str; };
     readOnly = mkOption { type = types.bool; default = false; };
     execStartPre = mkOption { type = types.nullOr types.str; default = null; };

--- a/services/bookmarks.nix
+++ b/services/bookmarks.nix
@@ -13,7 +13,7 @@ in
     enable = mkOption { type = types.bool; default = false; };
     image = mkOption { type = types.str; };
     httpPort = mkOption { type = types.int; default = 3000; };
-    esTag = mkOption { type = types.str; default = "7.11.2"; };
+    esTag = mkOption { type = types.str; default = "7.17.0"; };
     baseURI = mkOption { type = types.str; };
     readOnly = mkOption { type = types.bool; default = false; };
     execStartPre = mkOption { type = types.nullOr types.str; default = null; };

--- a/services/finder.nix
+++ b/services/finder.nix
@@ -13,7 +13,7 @@ in
     enable = mkOption { type = types.bool; default = false; };
     image = mkOption { type = types.str; };
     httpPort = mkOption { type = types.int; default = 3000; };
-    esTag = mkOption { type = types.str; default = "7.11.2"; };
+    esTag = mkOption { type = types.str; default = "7.17.0"; };
     execStartPre = mkOption { type = types.nullOr types.str; default = null; };
     dockerVolumeDir = mkOption { type = types.path; };
     mangaDir = mkOption { type = types.path; };


### PR DESCRIPTION
This is a prerequisite for upgrading to 8.0.0, going straight from
7.11 isn't allowed:

    java.lang.IllegalStateException: cannot upgrade a node from
    version [7.11.2] directly to version [8.0.0], upgrade to version
    [7.17.0] first.