### PR TITLE
Add Pi Hole service & enable on nyarlathotep

### DIFF
--- a/configuration.nix
+++ b/configuration.nix
@@ -15,6 +15,7 @@
     ./services/finder.nix
     ./services/gitea.nix
     ./services/minecraft.nix
+    ./services/pihole.nix
     ./services/pleroma.nix
     ./services/umami.nix
   ];

--- a/modules/erase-your-darlings.nix
+++ b/modules/erase-your-darlings.nix
@@ -73,6 +73,7 @@ in
     services.finder.dockerVolumeDir = "${toString cfg.persistDir}/docker-volumes/finder";
     services.gitea.dockerVolumeDir = "${toString cfg.persistDir}/docker-volumes/gitea";
     services.minecraft.dataDir = "${toString cfg.persistDir}/srv/minecraft";
+    services.pihole.dockerVolumeDir = "${toString cfg.persistDir}/docker-volumes/pihole";
     services.pleroma.dockerVolumeDir = "${toString cfg.persistDir}/docker-volumes/pleroma";
     services.umami.dockerVolumeDir = "${toString cfg.persistDir}/docker-volumes/umami";
   };

--- a/services/pihole.nix
+++ b/services/pihole.nix
@@ -1,0 +1,61 @@
+{ config, lib, ... }:
+
+with lib;
+let
+  cfg = config.services.pihole;
+  backend = config.virtualisation.oci-containers.backend;
+
+  # https://github.com/NixOS/nixpkgs/issues/104750
+  serviceConfigForContainerLogging = { StandardOutput = mkForce "journal"; StandardError = mkForce "journal"; };
+in
+{
+  # For now, static records (etc) are configyred by making changes to
+  # the docker volumes directly.
+  options.services.pihole = {
+    enable = mkOption { type = types.bool; default = false; };
+    dockerTag = mkOption { type = types.str; };
+    serverIP = mkOption { type = types.str; };
+    password = mkOption { type = types.nullOr types.str; default = null; };
+    upstreamDNS = mkOption { type = types.listOf types.str; default = [ "1.1.1.1" "8.8.8.8" ]; };
+    onlyLocalDNS = mkOption { type = types.bool; default = false; };
+    httpPort = mkOption { type = types.int; default = 3000; };
+    execStartPre = mkOption { type = types.nullOr types.str; default = null; };
+    dockerVolumeDir = mkOption { type = types.path; };
+  };
+
+  config = mkIf cfg.enable {
+    virtualisation.oci-containers.containers.pihole = {
+      autoStart = true;
+      image = "pihole/pihole:${cfg.dockerTag}";
+      environment = {
+        "WEBPASSWORD" = cfg.password;
+        "ServerIP" = cfg.serverIP;
+        "PIHOLE_DNS_" = concatStringsSep ";" cfg.upstreamDNS;
+      };
+      ports = [
+        "127.0.0.1:${toString cfg.httpPort}:80"
+        "${if cfg.onlyLocalDNS then "127.0.0.1:" else ""}53:53/tcp"
+        "${if cfg.onlyLocalDNS then "127.0.0.1:" else ""}53:53/udp"
+      ];
+      volumes = [
+        "${toString cfg.dockerVolumeDir}/etc-pihole:/etc/pihole"
+        "${toString cfg.dockerVolumeDir}/etc-dnsmasq.d:/etc/dnsmasq.d"
+      ];
+    };
+    systemd.services."${backend}-pihole" = {
+      preStart = mkIf (cfg.execStartPre != null) cfg.execStartPre;
+      serviceConfig = serviceConfigForContainerLogging;
+    };
+
+    services.prometheus.exporters.pihole.enable = config.services.prometheus.enable;
+    services.prometheus.exporters.pihole.piholeHostname = "pi.hole";
+    services.prometheus.exporters.pihole.password = cfg.password;
+
+    services.prometheus.scrapeConfigs = [
+      {
+        job_name = "${config.networking.hostName}-pihole";
+        static_configs = [{ targets = [ "localhost:${toString config.services.prometheus.exporters.pihole.port}" ]; }];
+      }
+    ];
+  };
+}


### PR DESCRIPTION
My Raspberry Pi has died - presumably SD card failure.  I don't have a spare SD card, and running this weird pet Debian server is something I've wanted to stop doing for a while, so I've decided to move DNS onto NixOS instead.

This isn't a perfect configuration-as-code solution, I still need to manually block or allow things through the Pi Hole web interface, and configure custom records through the dnsmasq config files, but at least that's now a small contained amount of state I can easily back up.  Ideally, though, everything would be done through configuration.