### PR TITLE
Open port 53 (TCP and UDP) for Pi Hole

### DIFF
--- a/services/pihole.nix
+++ b/services/pihole.nix
@@ -46,6 +46,9 @@ in
       serviceConfig = serviceConfigForContainerLogging;
     };
 
+    networking.firewall.allowedTCPPorts = [ 53 ];
+    networking.firewall.allowedUDPPorts = [ 53 ];
+
     services.prometheus.exporters.pihole.enable = config.services.prometheus.enable;
     services.prometheus.exporters.pihole.piholeHostname = "pi.hole";
     services.prometheus.exporters.pihole.password = cfg.password;


### PR DESCRIPTION
This is also needed to totally solve the docker issue described in
37f3dca.