### PR TITLE
Remove `trustedInterfaces` from nyarlathotep & azathoth

### DIFF
--- a/hosts/azathoth/configuration.nix
+++ b/hosts/azathoth/configuration.nix
@@ -25,9 +25,6 @@ in
   hardware.pulseaudio.enable = true;
   hardware.pulseaudio.support32Bit = true;
 
-  # Firewall
-  networking.firewall.trustedInterfaces = [ "enp6s0" ];
-
   # Nyarlathotep
   fileSystems."/home/barrucadu/nfs/anime" = nfsShare "anime";
   fileSystems."/home/barrucadu/nfs/manga" = nfsShare "manga";

--- a/hosts/nyarlathotep/configuration.nix
+++ b/hosts/nyarlathotep/configuration.nix
@@ -39,8 +39,7 @@ in
   modules.zfsAutomation.enable = true;
 
   # Firewall
-  networking.firewall.trustedInterfaces = [ "enp4s0" ];
-  networking.firewall.allowedTCPPorts = [ 8888 ]; # for testing stuff
+  networking.firewall.allowedTCPPorts = [ 80 8888 ];
 
   # Wipe / on boot
   modules.eraseYourDarlings.enable = true;


### PR DESCRIPTION
This defeats the point of configuring a firewall; though neither of those machines are exposed to the internet so it doesn't really matter.

I'm also tempted to remove

```nix
networking.firewall.trustedInterfaces = if config.virtualisation.docker.enable then [ "docker0" ] else [ ];
```

From the firewall module, but would need to think about how to test this is safe first.