### PR TITLE
Remove trailing reference to `services.pihole`

### DIFF
--- a/modules/erase-your-darlings.nix
+++ b/modules/erase-your-darlings.nix
@@ -73,7 +73,6 @@ in
     services.finder.dockerVolumeDir = "${toString cfg.persistDir}/docker-volumes/finder";
     services.gitea.dockerVolumeDir = "${toString cfg.persistDir}/docker-volumes/gitea";
     services.minecraft.dataDir = "${toString cfg.persistDir}/srv/minecraft";
-    services.pihole.dockerVolumeDir = "${toString cfg.persistDir}/docker-volumes/pihole";
     services.pleroma.dockerVolumeDir = "${toString cfg.persistDir}/docker-volumes/pleroma";
     services.umami.dockerVolumeDir = "${toString cfg.persistDir}/docker-volumes/umami";
   };


### PR DESCRIPTION
This was missed in 5cb0cde.