### PR TITLE
Set /etc/machine-id in erase-your-darlings mode

### DIFF
--- a/hosts/carcosa/configuration.nix
+++ b/hosts/carcosa/configuration.nix
@@ -54,6 +54,7 @@ in
 
   # Wipe / on boot
   modules.eraseYourDarlings.enable = true;
+  modules.eraseYourDarlings.machineId = "64b1b10f3bef4616a7faf5edf1ef3ca5";
   modules.eraseYourDarlings.barrucaduHashedPassword = fileContents /etc/nixos/secrets/passwd-barrucadu.txt;
 
 

--- a/hosts/nyarlathotep/configuration.nix
+++ b/hosts/nyarlathotep/configuration.nix
@@ -43,6 +43,7 @@ in
 
   # Wipe / on boot
   modules.eraseYourDarlings.enable = true;
+  modules.eraseYourDarlings.machineId = "0f7ae3bda2a9428ab77a0adddc4c8cff";
   modules.eraseYourDarlings.barrucaduHashedPassword = fileContents /etc/nixos/secrets/passwd-barrucadu.txt;
 
 

--- a/modules/erase-your-darlings.nix
+++ b/modules/erase-your-darlings.nix
@@ -13,6 +13,7 @@ in
         barrucaduHashedPassword = mkOption { type = types.str; };
         rootSnapshot = mkOption { type = types.str; default = "local/volatile/root@blank"; };
         persistDir = mkOption { type = types.path; default = "/persist"; };
+        machineId = mkOption { type = types.str; };
       };
     };
   };
@@ -22,6 +23,13 @@ in
     boot.initrd.postDeviceCommands = mkAfter ''
       zfs rollback -r ${cfg.rootSnapshot}
     '';
+
+    # Set /etc/machine-id, so that journalctl can access logs from
+    # previous boots.
+    environment.etc.machine-id = {
+      text = "${cfg.machineId}\n";
+      mode = "0444";
+    };
 
     # Switch back to immutable users
     users.mutableUsers = mkForce false;


### PR DESCRIPTION
While `/var/log` is preserved, journalctl can't actually access logs
from previous boots easily.  It only sees the current boot:

    $ journalctl --list-boots
     0 5ee8929892ac4b9fb3d4bcee29039c66 Sat 2022-04-02 12:55:06 BST—Sat 2022-04-02 13:14:42 BST

This is because it uses `/etc/machine-id` to identify which logs
belong to this machine, and so if that changes, the old logs exist but
can't easily be accessed.

Note: machine-id(5) says:

> This ID uniquely identifies the host. It should be considered
> "confidential", and must not be exposed in untrusted environments,
> in particular on the network.

And yet here I am committing it to a public git repository.  As far as
I can tell this is a privacy consideration, like MAC address exposure,
and not a security consideration.  So I don't think there's any risk
here.  And if I later discover some risk, I can generate new machine
IDs (since I've been changing them on every boot with no ill effects
beyond not being able to access journald logs from prior boots) and
put them in my secrets store.