### PR TITLE
Use `BindPaths` for Prometheus unit state dir

### DIFF
--- a/modules/erase-your-darlings.nix
+++ b/modules/erase-your-darlings.nix
@@ -1,4 +1,4 @@
-{ config, lib, pkgs, ... }:
+{ config, lib, ... }:
 
 with lib;
 
@@ -58,14 +58,7 @@ in
       "L+ /etc/nixos - - - - ${toString cfg.persistDir}/etc/nixos"
     ];
 
-    systemd.services.prometheus-statedir = {
-      enable = config.services.prometheus.enable;
-      description = "Bind-mount prometheus StateDirectory";
-      after = [ "local-fs.target" ];
-      wantedBy = [ "prometheus.service" ];
-      serviceConfig.ExecStartPre = "${pkgs.coreutils}/bin/mkdir -p /var/lib/${config.services.prometheus.stateDir}";
-      serviceConfig.ExecStart = "${pkgs.utillinux}/bin/mount -o bind ${toString cfg.persistDir}/var/lib/${config.services.prometheus.stateDir} /var/lib/${config.services.prometheus.stateDir}";
-    };
+    systemd.services.prometheus.serviceConfig.BindPaths = "${toString cfg.persistDir}/var/lib/${config.services.prometheus.stateDir}:/var/lib/${config.services.prometheus.stateDir}";
 
     services.caddy.dataDir = "${toString cfg.persistDir}/var/lib/caddy";
     services.dockerRegistry.storagePath = "${toString cfg.persistDir}/var/lib/docker-registry";


### PR DESCRIPTION
It's not clear from the systemd documentation[1] that this will work,
but I've tested it by stopping prometheus, unmounting the bind-mount,
rebuilding the configuration, starting prometheus, and seeing that new
metrics appear and old metrics are still available.

[1] https://www.freedesktop.org/software/systemd/man/systemd.exec.html