### PR TITLE
Remove grafana override for erase-your-darlings

### DIFF
--- a/modules/erase-your-darlings.nix
+++ b/modules/erase-your-darlings.nix
@@ -62,7 +62,6 @@ in
 
     services.caddy.dataDir = "${toString cfg.persistDir}/var/lib/caddy";
     services.dockerRegistry.storagePath = "${toString cfg.persistDir}/var/lib/docker-registry";
-    services.grafana.dataDir = "${toString cfg.persistDir}/var/lib/grafana";
     services.syncthing.dataDir = "${toString cfg.persistDir}/var/lib/syncthing";
 
     # my services


### PR DESCRIPTION
This was originally added so I could use a pie chart plugin, but
grafana has long had its own pie chart panel type now.