### PR TITLE
Bump `system.stateVersion` to 21.11

### DIFF
--- a/common.nix
+++ b/common.nix
@@ -9,7 +9,7 @@ with lib;
     #############################################################################
 
     # The NixOS release to be compatible with for stateful data such as databases.
-    system.stateVersion = "17.03";
+    system.stateVersion = "21.11";
 
     # Only keep the last 500MiB of systemd journal.
     services.journald.extraConfig = "SystemMaxUse=500M";


### PR DESCRIPTION
This is safe to do, because none of the changes affect me.

Here are all mentions of the `stateVersion` in the release notes since
17.03.

**NixOS 21.11:**

No mentions.

**NixOS 21.05:**

- CodiMD has been renamed to HedgeDoc, and associated suernames and
directories have been renamed.  I don't use CodiMD.

- Radicale no longer uses the state version to determine package
version.  I don't use Radicale.

**NixOS 20.09:**

- Supybot uses a different state directory and has some different
systemd sandboxing options.  I don't use Supybot.

- Deluge uses the state version to determine package version.  I don't
use Deluge.

- Postgres no longer uses state version to determine data directory
location.  I do use Postgres, but not the NixOS package: only
dockerised.

- Jellyfin uses the state version to determine package version.  I
don't use Jellyfin.

**NixOS 20.03:**

- Nextcloud uses the state version to determine package version.  I
don't use Nextcloud.

- Hydra uses the state version to determine package version.  I don't
use Hydra.

**NixOS 19.09:**

- The xterm desktop manager is disabled by default.  I don't use the
xterm desktop manager.

- Solr uses the state version to determine the package version.  I
don't use solr.

**NixOS 19.03:**

No mentions.

**NixOS 18.09:**

No mentions.

**NixOS 18.03:**

- matrix-synapse uses postgres instead of sqlite.  I don't use
matrix-synapse.

**NixOS 17.09:**

- The Postgres version, data directory, and superuser name was
changed.  I don't use the NixOS Postgres package.

- The MySQL data directory was changed.  I don't use MySQL.

**NixOS 17.03:**

No mentions.