### PR TITLE
[carcosa] Add a Foundry VTT service

### DIFF
--- a/hosts/carcosa/configuration.nix
+++ b/hosts/carcosa/configuration.nix
@@ -402,6 +402,16 @@ in
         { command = "${pkgs.systemd}/bin/systemctl restart docker-pleroma"; options = [ "NOPASSWD" ]; }
       ];
     }
+    # for backup scripts
+    {
+      users = [ "barrucadu" ];
+      commands = [
+        { command = "${pkgs.systemd}/bin/systemctl stop foundryvtt"; options = [ "NOPASSWD" ]; }
+        { command = "${pkgs.systemd}/bin/systemctl start foundryvtt"; options = [ "NOPASSWD" ]; }
+        { command = "${pkgs.gnutar}/bin/tar cfz foundryvtt.tar.gz /persist/srv/foundry"; options = [ "NOPASSWD" ]; }
+        { command = "${pkgs.coreutils}/bin/chown barrucadu.users foundryvtt.tar.gz"; options = [ "NOPASSWD" ]; }
+      ];
+    }
   ];
 
   # Extra packages

--- a/hosts/carcosa/configuration.nix
+++ b/hosts/carcosa/configuration.nix
@@ -11,6 +11,7 @@ let
   pleromaPort = 3007;
   concourseMetricsPort = 3009;
   grafanaPort = 3010;
+  foundryPort = 3011;
 
   pullDevDockerImage = pkgs.writeShellScript "pull-dev-docker-image.sh" ''
     set -e
@@ -127,6 +128,11 @@ in
     bookmarks.barrucadu.co.uk {
       import common_config
       reverse_proxy http://127.0.0.1:${toString config.services.bookmarks.httpPort}
+    }
+
+    foundry.barrucadu.co.uk {
+      import common_config
+      reverse_proxy http://localhost:${toString foundryPort}
     }
 
     memo.barrucadu.co.uk {
@@ -342,6 +348,27 @@ in
   services.minecraft.servers.tea = {
     port = 25565;
     jar = "fabric-server-launch.jar";
+  };
+
+  # Foundry VTT
+  systemd.services.foundryvtt = {
+    enable = true;
+    description = "Foundry Virtual Tabletop";
+    wantedBy = [ "multi-user.target" ];
+    after = [ "network.target" ];
+    serviceConfig = {
+      ExecStart = "${pkgs.nodejs-17_x}/bin/node resources/app/main.js --dataPath=/persist/srv/foundry/data --port=${toString foundryPort}";
+      Restart = "always";
+      User = "foundryvtt";
+      WorkingDirectory = "/persist/srv/foundry/bin";
+    };
+  };
+  users.users.foundryvtt = {
+    description = "Foundry VTT service user";
+    home = "/persist/srv/foundry";
+    createHome = true;
+    isSystemUser = true;
+    group = "nogroup";
   };
 
 


### PR DESCRIPTION
I'm looking into Foundry VTT as a replacement for Roll20.  I've been paying for a Roll20 pro membership for 8 or 9 months now, just so I can use custom character sheets for Traveller.  But Foundry has a pretty good looking unofficial Traveller system, which I should try out.