### PR TITLE
Remove `--impure` flag from auto-upgrade task

### DIFF
--- a/common.nix
+++ b/common.nix
@@ -52,7 +52,7 @@ with lib;
     # Upgrade packages and reboot if needed
     system.autoUpgrade.enable = true;
     system.autoUpgrade.allowReboot = true;
-    system.autoUpgrade.flags = [ "--update-input" "nixpkgs" "--impure" ];
+    system.autoUpgrade.flags = [ "--update-input" "nixpkgs" ];
     system.autoUpgrade.dates = "06:45";
 
     #############################################################################

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1657296039,
-        "narHash": "sha256-Ghh39+aS+pw5sTP/ZO8VIKE6sBhMadDaQZtf+3yu4Vc=",
+        "lastModified": 1657476024,
+        "narHash": "sha256-4xnAf6VxE/efOwHt/MsG/g1gmpT78n/8oHqF1atzNjI=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "71d7a4c037dc4f3e98d5c4a81b941933cf5bf675",
+        "rev": "cf034a867e08b7e083df1658c915c58456dbbde2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
This is no longer necessary now that I've moved to sops-nix for
secrets and moved the lainonlife pleroma favicon into a subdirectory.