### PR TITLE
Reduce number of zfs monthly snapshots to 3

### DIFF
--- a/modules/zfs-automation.nix
+++ b/modules/zfs-automation.nix
@@ -27,6 +27,10 @@ in
 
     # Auto-snapshot is enabled per dataset:
     # run `sudo zfs set com.sun:auto-snapshot=true <dataset>`
+    #
+    # The default of 12 monthly snapshots takes up too much disk space
+    # in practice.
     services.zfs.autoSnapshot.enable = true;
+    services.zfs.autoSnapshot.monthly = 3;
   };
 }


### PR DESCRIPTION
I noticed that these snapshots were using up a huge amount of disk
space on nyarlathotep and carcosa, to the extend of causing problems
for other things (eg, taking a full backup resulting in running out of
disk space)