### PR TITLE
Add a service file for Foundry

### DIFF
--- a/common.nix
+++ b/common.nix
@@ -13,6 +13,7 @@ with lib;
     ./services/bookmarks.nix
     ./services/concourse.nix
     ./services/finder.nix
+    ./services/foundryvtt.nix
     ./services/minecraft.nix
     ./services/pleroma.nix
     ./services/resolved.nix

--- a/hosts/carcosa/configuration.nix
+++ b/hosts/carcosa/configuration.nix
@@ -151,7 +151,7 @@ in
 
     foundry.barrucadu.co.uk {
       import common_config
-      reverse_proxy http://localhost:${toString foundryPort}
+      reverse_proxy http://localhost:${toString config.services.foundryvtt.port}
     }
 
     memo.barrucadu.co.uk {
@@ -361,33 +361,8 @@ in
   };
 
   # Foundry VTT
-  systemd.services.foundryvtt = {
-    enable = true;
-    description = "Foundry Virtual Tabletop";
-    wantedBy = [ "multi-user.target" ];
-    after = [ "network.target" ];
-    serviceConfig = {
-      ExecStart = "${pkgs.nodejs-18_x}/bin/node resources/app/main.js --dataPath=/persist/srv/foundry/data --port=${toString foundryPort}";
-      Restart = "always";
-      User = "foundryvtt";
-      WorkingDirectory = "/persist/srv/foundry/bin";
-    };
-  };
-  users.users.foundryvtt = {
-    description = "Foundry VTT service user";
-    home = "/persist/srv/foundry";
-    createHome = true;
-    isSystemUser = true;
-    group = "nogroup";
-  };
-  # TODO: figure out how to get `sudo` in the unit's path (adding the
-  # package doesn't help - need the wrapper)
-  modules.backupScripts.scripts.foundryvtt = ''
-    /run/wrappers/bin/sudo systemctl stop foundryvtt
-    /run/wrappers/bin/sudo tar cfz dump.tar.gz /persist/srv/foundry
-    /run/wrappers/bin/sudo chown barrucadu.users dump.tar.gz
-    /run/wrappers/bin/sudo systemctl start foundryvtt
-  '';
+  services.foundryvtt.enable = true;
+  services.foundryvtt.port = foundryPort;
 
 
   ###############################################################################
@@ -421,16 +396,6 @@ in
         { command = "${pkgs.systemd}/bin/systemctl restart docker-bookdb"; options = [ "NOPASSWD" ]; }
         { command = "${pkgs.systemd}/bin/systemctl restart docker-bookmarks"; options = [ "NOPASSWD" ]; }
         { command = "${pkgs.systemd}/bin/systemctl restart docker-pleroma"; options = [ "NOPASSWD" ]; }
-      ];
-    }
-    # for backup scripts
-    {
-      users = [ "barrucadu" ];
-      commands = [
-        { command = "${pkgs.systemd}/bin/systemctl stop foundryvtt"; options = [ "NOPASSWD" ]; }
-        { command = "${pkgs.systemd}/bin/systemctl start foundryvtt"; options = [ "NOPASSWD" ]; }
-        { command = "${pkgs.gnutar}/bin/tar cfz dump.tar.gz /persist/srv/foundry"; options = [ "NOPASSWD" ]; }
-        { command = "${pkgs.coreutils}/bin/chown barrucadu.users dump.tar.gz"; options = [ "NOPASSWD" ]; }
       ];
     }
   ];

--- a/modules/erase-your-darlings.nix
+++ b/modules/erase-your-darlings.nix
@@ -69,6 +69,7 @@ in
     services.bookmarks.dockerVolumeDir = "${toString cfg.persistDir}/docker-volumes/bookmarks";
     services.concourse.dockerVolumeDir = "${toString cfg.persistDir}/docker-volumes/concourse";
     services.finder.dockerVolumeDir = "${toString cfg.persistDir}/docker-volumes/finder";
+    services.foundryvtt.dataDir = "${toString cfg.persistDir}/srv/foundry";
     services.minecraft.dataDir = "${toString cfg.persistDir}/srv/minecraft";
     services.pleroma.dockerVolumeDir = "${toString cfg.persistDir}/docker-volumes/pleroma";
     services.umami.dockerVolumeDir = "${toString cfg.persistDir}/docker-volumes/umami";

--- a/services/foundryvtt.nix
+++ b/services/foundryvtt.nix
@@ -1,0 +1,59 @@
+# FoundryVTT is licensed software and needs to be downloaded after
+# purchase.
+
+{ config, lib, pkgs, ... }:
+
+with lib;
+let
+  cfg = config.services.foundryvtt;
+in
+{
+  options.services.foundryvtt = {
+    enable = mkOption { type = types.bool; default = false; };
+    port = mkOption { type = types.int; default = 3000; };
+    dataDir = mkOption { type = types.str; default = "/srv/foundry"; };
+  };
+
+  config = mkIf cfg.enable {
+    systemd.services.foundryvtt = {
+      enable = true;
+      description = "Foundry Virtual Tabletop";
+      wantedBy = [ "multi-user.target" ];
+      after = [ "network.target" ];
+      serviceConfig = {
+        ExecStart = "${pkgs.nodejs-18_x}/bin/node resources/app/main.js --dataPath=${cfg.dataDir}/data --port=${toString cfg.port}";
+        Restart = "always";
+        User = "foundryvtt";
+        WorkingDirectory = "${cfg.dataDir}/bin";
+      };
+    };
+
+    users.users.foundryvtt = {
+      description = "Foundry VTT service user";
+      home = cfg.dataDir;
+      createHome = true;
+      isSystemUser = true;
+      group = "nogroup";
+    };
+
+    # TODO: figure out how to get `sudo` in the unit's path (adding the
+    # package doesn't help - need the wrapper)
+    modules.backupScripts.scripts.foundryvtt = ''
+      /run/wrappers/bin/sudo systemctl stop foundryvtt
+      /run/wrappers/bin/sudo tar cfz dump.tar.gz ${cfg.dataDir}
+      /run/wrappers/bin/sudo chown ${config.modules.backupScripts.user}.${config.modules.backupScripts.group} dump.tar.gz
+      /run/wrappers/bin/sudo systemctl start foundryvtt
+    '';
+    security.sudo.extraRules = [
+      {
+        users = [ config.modules.backupScripts.user ];
+        commands = [
+          { command = "${pkgs.systemd}/bin/systemctl stop foundryvtt"; options = [ "NOPASSWD" ]; }
+          { command = "${pkgs.systemd}/bin/systemctl start foundryvtt"; options = [ "NOPASSWD" ]; }
+          { command = "${pkgs.gnutar}/bin/tar cfz dump.tar.gz ${cfg.dataDir}"; options = [ "NOPASSWD" ]; }
+          { command = "${pkgs.coreutils}/bin/chown ${config.modules.backupScripts.user}.${config.modules.backupScripts.group} dump.tar.gz"; options = [ "NOPASSWD" ]; }
+        ];
+      }
+    ];
+  };
+}


### PR DESCRIPTION
Foundry's got a few different bits of config now, so move it all to a
new file (even though it's only used by carcosa).

This relies on the Foundry files being in the right place.  Since
Foundry is nonfree software which has to be downloaded from the online
store after purchase, that seems unavoidable.