### PR TITLE
Import monitoring-scripts & rename to `services.monitoring`

### DIFF
--- a/common.nix
+++ b/common.nix
@@ -6,7 +6,6 @@ with lib;
   imports = [
     ./modules/erase-your-darlings.nix
     ./modules/firewall.nix
-    ./modules/monitoring-scripts.nix
     ./modules/zfs-automation.nix
     ./services/backups.nix
     ./services/bookdb.nix
@@ -15,6 +14,7 @@ with lib;
     ./services/finder.nix
     ./services/foundryvtt.nix
     ./services/minecraft.nix
+    ./services/monitoring.nix
     ./services/pleroma.nix
     ./services/resolved.nix
     ./services/umami.nix

--- a/hosts/carcosa/configuration.nix
+++ b/hosts/carcosa/configuration.nix
@@ -58,6 +58,11 @@ in
   modules.eraseYourDarlings.barrucaduPasswordFile = config.sops.secrets."users/barrucadu".path;
   sops.secrets."users/barrucadu".neededForUsers = true;
 
+  # Monitoring
+  modules.monitoringScripts.enable = true;
+  modules.monitoringScripts.environmentFile = config.sops.secrets."modules/monitoring_scripts/env".path;
+  sops.secrets."modules/monitoring_scripts/env" = { };
+
 
   ###############################################################################
   ## Backups

--- a/hosts/carcosa/configuration.nix
+++ b/hosts/carcosa/configuration.nix
@@ -59,9 +59,9 @@ in
   sops.secrets."users/barrucadu".neededForUsers = true;
 
   # Monitoring
-  modules.monitoringScripts.enable = true;
-  modules.monitoringScripts.environmentFile = config.sops.secrets."modules/monitoring_scripts/env".path;
-  sops.secrets."modules/monitoring_scripts/env" = { };
+  services.monitoring.enable = true;
+  services.monitoring.environmentFile = config.sops.secrets."services/monitoring/env".path;
+  sops.secrets."services/monitoring/env" = { };
 
 
   ###############################################################################

--- a/hosts/carcosa/secrets.yaml
+++ b/hosts/carcosa/secrets.yaml
@@ -11,13 +11,13 @@ services:
     grafana:
         admin_password: ENC[AES256_GCM,data:nGzl+HjDKz/ushife6YLCXtzTpIlHrbqPFWxsV3QxhG5FwXj5+vPNo8Pyg==,iv:j+ZS5PXFqV7t/mGK5lRQv0pG7+sh2BHy3N7MQ0YgWTY=,tag:F9r2iiMxG4xnFIz0vnP88w==,type:str]
         secret_key: ENC[AES256_GCM,data:KeWJ9AVXCYjFgaFWbV7rqGRKOLT+lqzLP/p3Dajnemk=,iv:rfcm8PordRN0bCQmIQ7flZ/ShaCG1X30wUtHDjLD79Q=,tag:C+Ze2RmQ9yfR5/6K6oMqlA==,type:str]
+    monitoring:
+        env: ENC[AES256_GCM,data:KWMRhgr3cAPle40EypC+032ueow7ZRXsRuRPyhj8tNFlgHAC7dsUJzhJkdPnXnhIOVrTFrDXX/riWrqfJFuSN9x1mICF5w+aRPa0ADIMdV4vKaQJ0+cAuzzSRNG6VHmJKkE3qxzFsngPYqdWVU4vCsjfjiX5NjCZVRTTqX4pQ4kDT1TbZTIlN2z47SdM6YzA5fbxo4wql3DvW/RCGY4sGUxiTZKvlTxZcX2ObpETkAhI5XQ6ZnCQ6oBlLT/N62ahJYT92g==,iv:jHQKt+zRubXJd0yCTO4uBWZ/JnPto6egC4tueR+UUe0=,tag:hTWjPdsljf5dOPMFK/V2oQ==,type:str]
     pleroma:
         exc: ENC[AES256_GCM,data:dhIEA8IJ1krxgktpMRrpQcCK41n8qEDVq8kzLPCwj9cg1yZdCwNtk9kAOTTECbHFeiB0MwpE4N50WRxAGh3OZkqlUf40ziiOcR49RMteBuBRhxmEfRi6W/sJK8PvtBaFr2v75+sZPVBQQf3KPCXKSCvvk0iLQ/xr6fNEgbXJsR8QLAlrEGqnGS6FJYl0HVnNIF9R+xrQy4UUIeEF2tRKHNZ3/vH+yyGBkAuYr2TbH+ycPfx7uxNarrk+8roqYHbUIMugEWsn2hv8JOsN/UvfpaLyH9BWoXmgGpM/Q76HE9E7pXkklusbjCYgoUVeUyLyINkvx8AtAuRV6DXk3uYzH7PSvG/XWNG3Tk6oZ96Y9sgBols70EG6pDN08+HiZOupa6PtvrzYIHN3ND9U7LZONHj51B+hBWtfWWjk2GtIjjQtzEKPfy/GihC3tBfbu/v6vtPtBi9u94LPxMMUCAHHr/kOZrUuKkS1MsfSia3Uoq2jsgj+a5g+TUXgK5c=,iv:aE0UH0smmYhLUlUZDuYr+3R3p0MRweKppMLT8jQiIrk=,tag:HxasrVjQphxCf9C5mxGVSA==,type:str]
     umami:
         env: ENC[AES256_GCM,data:ZevFxJ3ZJTyOJt4ajOjNyicZC1vmZejgcehc3NDmoEszBjSXrmHXxGMZ0RPGW39WHOJJOq85jFoR92ldwCp1kuuxDYCF+7T8H7AP,iv:YWehCGmFlF2SoRP3IULFnY6XDn4w3U2HHxScevbjQIM=,tag:1oHLRofc8pFbXgLa7FvGRQ==,type:str]
 modules:
-    monitoring_scripts:
-        env: ENC[AES256_GCM,data:IJwR4vxDbfdPsls59YtsU8ZuEdA+xn5dhLGBMyb14S0O5kqQwjbl4cIwh4K3+RlozSVw8pMaFHlxUx0BcNskD4FWW7moiGtumvzB0f4j3nZAHnODl/nedBVqQbI6rk/VstQTjj99lPsedBjotRGLSEBdYXueazFZl7iCA8cOFxOKmC54c5ewaVJUT5AO1wqSbC3wTdwRGhzkHLGJ/qVhCKzKuJEhtFV7wV7DPbRDLilMKBEneJiH3T4LRFOit27joNFJtQ==,iv:0UHByVpZxtnhM5CW7rdnBtBiLx83VeS9zXjBGwrx/0c=,tag:qDYNqUTrwXByY3K86DYPDA==,type:str]
     firewall:
         ip_blocklist: ENC[AES256_GCM,data:LfIvjgXQpkATyEonKlthMWaFgwYlUlhyVh/XSA2uNjUTAUcSmJfaId0AYRiZrq/xC2kS+RqY9DOcPfr7RKomu246N7Z71pWokgp2uMa0pY+8xIJ/dfJLzgr9gZOdO2160xaaYw==,iv:/yoLguZRO2foAQvs7KzRaN+en5EfALYEEd9ZQFcpYBo=,tag:XSKz7/qZf73nUWEE8+dfIQ==,type:str]
 sops:
@@ -44,8 +44,8 @@ sops:
             dTQwclBRU3JmQ2hBOFVlaVIxZHN4cVEKvVR1bSH4yo2Td8YGNI2hmflT0M3hcYu8
             qyYoWd5MFP9VBYKxrF8W2naQSY6Ax4IiVuNbKDDLFooTC93V+oxNDA==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2022-07-25T19:25:55Z"
-    mac: ENC[AES256_GCM,data:WzYu4fqNfgx4WWA+TBASAe5S3m1QMhp6pJWqWHrLQD4VAI1/pPRYOBEwch6rTeNF2n+n54006z94yXW2YAoNk88QK20GQFViBtr0Mj8EYOpsEMNuXkSiu7EJeS965uc9JiFpkZkeJql1aQdb9zs2zHpuHVR/Bk/6J46DDjAVOrk=,iv:31d46xw9/yAH67GQWlawDnhBwzg0t7D5F3/73PewuEw=,tag:SSlv8wFx7Q0p4rq1NqtYdg==,type:str]
+    lastmodified: "2022-07-25T19:32:54Z"
+    mac: ENC[AES256_GCM,data:HuodJzrW2pB50gqwORRmWTSrPd+4EigWgt2JpCP3xQEXbepWDHswyaxT5KOjf7d+F2BbedH5RivppK4Flw0SNSvGzsLadq47obj+KGmttYNqWEP0gu2gUK87i5xZ4jAgM+4+C98r7PFsYc8HWVFvh5NIqsSDbmiOPzpshdVGlMw=,iv:mnuy1CLfvVTLAdSQkgoRwe0WLw9dALPN8DSmO0X9WIo=,tag:4GibspaIMtGMdbKEt9snvQ==,type:str]
     pgp: []
     unencrypted_suffix: _unencrypted
     version: 3.7.3

--- a/hosts/carcosa/secrets.yaml
+++ b/hosts/carcosa/secrets.yaml
@@ -16,6 +16,8 @@ services:
     umami:
         env: ENC[AES256_GCM,data:ZevFxJ3ZJTyOJt4ajOjNyicZC1vmZejgcehc3NDmoEszBjSXrmHXxGMZ0RPGW39WHOJJOq85jFoR92ldwCp1kuuxDYCF+7T8H7AP,iv:YWehCGmFlF2SoRP3IULFnY6XDn4w3U2HHxScevbjQIM=,tag:1oHLRofc8pFbXgLa7FvGRQ==,type:str]
 modules:
+    monitoring_scripts:
+        env: ENC[AES256_GCM,data:IJwR4vxDbfdPsls59YtsU8ZuEdA+xn5dhLGBMyb14S0O5kqQwjbl4cIwh4K3+RlozSVw8pMaFHlxUx0BcNskD4FWW7moiGtumvzB0f4j3nZAHnODl/nedBVqQbI6rk/VstQTjj99lPsedBjotRGLSEBdYXueazFZl7iCA8cOFxOKmC54c5ewaVJUT5AO1wqSbC3wTdwRGhzkHLGJ/qVhCKzKuJEhtFV7wV7DPbRDLilMKBEneJiH3T4LRFOit27joNFJtQ==,iv:0UHByVpZxtnhM5CW7rdnBtBiLx83VeS9zXjBGwrx/0c=,tag:qDYNqUTrwXByY3K86DYPDA==,type:str]
     firewall:
         ip_blocklist: ENC[AES256_GCM,data:LfIvjgXQpkATyEonKlthMWaFgwYlUlhyVh/XSA2uNjUTAUcSmJfaId0AYRiZrq/xC2kS+RqY9DOcPfr7RKomu246N7Z71pWokgp2uMa0pY+8xIJ/dfJLzgr9gZOdO2160xaaYw==,iv:/yoLguZRO2foAQvs7KzRaN+en5EfALYEEd9ZQFcpYBo=,tag:XSKz7/qZf73nUWEE8+dfIQ==,type:str]
 sops:
@@ -42,8 +44,8 @@ sops:
             dTQwclBRU3JmQ2hBOFVlaVIxZHN4cVEKvVR1bSH4yo2Td8YGNI2hmflT0M3hcYu8
             qyYoWd5MFP9VBYKxrF8W2naQSY6Ax4IiVuNbKDDLFooTC93V+oxNDA==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2022-07-25T18:54:37Z"
-    mac: ENC[AES256_GCM,data:2NGcMZbFBfMEidCUl5NmM8zuzktct7lKb3oPNv9nZnPcxcDK+1ZF7BUzt4aKZ/PZySQLuMJ75rhYzulpjjkQkl4A5dxHFyF876xK2Z4xq81Y88XRn/hPIL8eSLcbK1S/dLzbxL6bZ7M0w3mQoTnRyEZVETjGlCqZcvDRXaTPn4c=,iv:TUBTVnwKGExJC2pyHNmA9ekQVDrraqvmHTBh0KiI2r4=,tag:k24QlajyNVciLhhCi2WzQA==,type:str]
+    lastmodified: "2022-07-25T19:25:55Z"
+    mac: ENC[AES256_GCM,data:WzYu4fqNfgx4WWA+TBASAe5S3m1QMhp6pJWqWHrLQD4VAI1/pPRYOBEwch6rTeNF2n+n54006z94yXW2YAoNk88QK20GQFViBtr0Mj8EYOpsEMNuXkSiu7EJeS965uc9JiFpkZkeJql1aQdb9zs2zHpuHVR/Bk/6J46DDjAVOrk=,iv:31d46xw9/yAH67GQWlawDnhBwzg0t7D5F3/73PewuEw=,tag:SSlv8wFx7Q0p4rq1NqtYdg==,type:str]
     pgp: []
     unencrypted_suffix: _unencrypted
     version: 3.7.3

--- a/hosts/nyarlathotep/configuration.nix
+++ b/hosts/nyarlathotep/configuration.nix
@@ -46,10 +46,10 @@ in
   sops.secrets."users/barrucadu".neededForUsers = true;
 
   # Monitoring
-  modules.monitoringScripts.enable = true;
-  modules.monitoringScripts.onCalendar = "0/12:00:00";
-  modules.monitoringScripts.environmentFile = config.sops.secrets."modules/monitoring_scripts/env".path;
-  sops.secrets."modules/monitoring_scripts/env" = { };
+  services.monitoring.enable = true;
+  services.monitoring.onCalendar = "0/12:00:00";
+  services.monitoring.environmentFile = config.sops.secrets."services/monitoring/env".path;
+  sops.secrets."services/monitoring/env" = { };
 
 
   ###############################################################################

--- a/hosts/nyarlathotep/configuration.nix
+++ b/hosts/nyarlathotep/configuration.nix
@@ -27,10 +27,6 @@ in
 
   sops.defaultSopsFile = ./secrets.yaml;
 
-  # Only run monitoring scripts every 12 hours: I can't replace a
-  # broken HDD if I'm away from home.
-  modules.monitoringScripts.onCalendar = "0/12:00:00";
-
   # Bootloader
   boot.loader.systemd-boot.enable = true;
 
@@ -48,6 +44,12 @@ in
   modules.eraseYourDarlings.machineId = "0f7ae3bda2a9428ab77a0adddc4c8cff";
   modules.eraseYourDarlings.barrucaduPasswordFile = config.sops.secrets."users/barrucadu".path;
   sops.secrets."users/barrucadu".neededForUsers = true;
+
+  # Monitoring
+  modules.monitoringScripts.enable = true;
+  modules.monitoringScripts.onCalendar = "0/12:00:00";
+  modules.monitoringScripts.environmentFile = config.sops.secrets."modules/monitoring_scripts/env".path;
+  sops.secrets."modules/monitoring_scripts/env" = { };
 
 
   ###############################################################################

--- a/hosts/nyarlathotep/secrets.yaml
+++ b/hosts/nyarlathotep/secrets.yaml
@@ -6,9 +6,8 @@ services:
         env: ENC[AES256_GCM,data:5zHKBFpljPd3d5kv9e1CG3mTsS4H647ysFiui25fdIRv3uDfvrBZxgW+2scQ0GOrhcuLfYgH34ZjBs3eCboNICXiWnXrgQG0AZafoN6vgaf+NjikMPRabylJDE68m+Gg1zJrUx3tX5Ohp01X7zfj81qxvgj/XDyCJ+33n+7nHFTCrv4fuLg8y+58B80V1iZsoL8eDIIJS0sQ7wYSf26uZPAoaGxabc7gvUqzjyuBHlMp+63fSoOo+87kpBKLzntN7b46BJzKocpsO972Qemp5COvxsi14hT8u/57L32tR7+LhB60JfxnPyhBEzAo9lkkGGPDVD64xct8hWjHKj+VsTLpedJg8psh1GngpISEmfEyRfaG8K4mGdpF4CzNtiI7E1tHuCFmNcYDblHX85QfF5XC4CX5Et/3wzZbGBWUgdNGO9kkX0IUmhUDKK5xRVlluQ90Lr9BCjC5lpK5EblgmOydshRTBkG74E0pXt2m6Qm+moWcBfeWYLzwYjt2R5jm8yZy/BNAupq3b0V08flS+jRCC4AOX9tHbc/5teuTnLym152S7ZZyA6y3GR2KYSbf8hF0fqhT2dBTnGAIH0ipzoSkZZHLJ4pUqjD5Y8WCkgddB4+4jolYbh2JFrnGoqw58U4ZG4a97IFhwg/JECLaHiFRBkdbOPy/7brAc/2bjraBRro4fw4U2nRmueL0U1Gs9AFQ61vl6u+Gnb3jh3sWGj5RIM8DgEiA8jQ5g2nq3+H0jdFVhByBGA9RrMDOGbIw5PCPrOrdg2OOitYn4Qdk1p9vFI9JfZUw6PLc+8s+w7fB4VLe8Hk9s7teuRicDhM0meE4Hap5x/Hw3+tNcSXgnXi1vPhC/3gWDTwU6JcepO+iIsdff5e5qf3r6/rNOaNvuFQnWiIC0tXxUwLf0tcnJ3ftr+uogWlTu2jAbhIflVSnvYJKAC973BxlQ2vRc572n1VLFADpO6iFQD+UCYu96tXsbENiK4RoSEYXI1PQoYnOt7rRTvqPaX8REkFk67lvUzH6y4QUcahBIU/wTXDQMxQSPk/d1ofZbbAKfxCjRjRDgw9LXbOgrSCOiqwHYzXa0LujnXkadbQF7l3/5X5LRRMjE7kpdfTSv4Ow5wZ5hK2ZH+DpzfL005c=,iv:VxUWqrsBEl0MzMtypoVCc4X1ZrhbWZYvOkbd/S3Drxo=,tag:6AE0Ucsm6uEQojIFO7xwkw==,type:str]
     bookmarks:
         env: ENC[AES256_GCM,data:VlFj0KFkJDmH80x3tK7tMXTC5Jqtm6TQNWgLdXXsTIMwqEwD6+t33xbFZOKA6hqCqMULWytpjcM=,iv:zy03NVR68LkfpWdr3J6lu8oEGt1buOSEtgTTAG0S+ok=,tag:lz29fKAIUS2FReox8u6SQw==,type:str]
-modules:
-    monitoring_scripts:
-        env: ENC[AES256_GCM,data:VCzUdg6XbkO0MCG9fMQyQdnlkwKnfslpXWgRpPzXu30JAryQGEK0+fggtMTLWgajeCsaxytzt8eClVXZ9yFXHLeUPTMAJ8tvOlPXK/wVurt8B/8v3bsopkxeIDC0vyo7UcJ93u6n67thgw8/GO/jMOCepuMkttilaUbB3pBtHv6uUATAY7u8GizwnfU6Hsg0RHk8ki2pysC+F2Srwa57bGeTVoGpbutslMCw1yfZYrk7zszH0gmBK1tGLQzbGVJKwNH51w==,iv:qnX73ec0GclyseUvNjKDbtPJmiehdPP4Ns4IVj0zpg8=,tag:ziGc4dI834bUVXpy88SXgA==,type:str]
+    monitoring:
+        env: ENC[AES256_GCM,data:GEY5igFPmgxdH8l6rB7Dz3iFXxLb3BPIPRk1Cd66DzJcGhMVwJxoFFvEUMQF4nKNVzkG/mxuBg7xSpZoEn4xugmIaFpJWd2rfM44Ku5+v6Y3TyKL/crQKR/0ryHHaTL39etXu84k8+GhxH7n5E8iwNdMyEkcFCNfdTnrUZaxzfRWGIJfzqq1usJ0uOSlZxIR/S/ONz0b2ShaqSfsm+m1mgPjnnNuUH5UzPNJ4A1Vfjchbi4sdOE/o5C3Vx2RUeEW3DQ6wA==,iv:/9OKazABBXn/OUCw5r/I2pMOwAk47rBcCT32neSsZFY=,tag:f9cxttlvhKJgLphzQg1gkg==,type:str]
 sops:
     kms: []
     gcp_kms: []
@@ -33,8 +32,8 @@ sops:
             cm5kRU1DeE1MdUdVSnY5L1FQNUE2SFEKnJKjCFW392HIH3CsLhco997rmHBY0XTb
             GwMV2j01l/1y0ItN7JcM0gpMLXPQw36iuKVo5voSkFUgyfTw9/f+FQ==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2022-07-25T19:26:20Z"
-    mac: ENC[AES256_GCM,data:361QQFh0Dut+vl2IaabrvpG/olOQLdsLn2xPwnyYyfyZU6HwKh27kOWPVlF9xzFL7/gQ6EKFmHnhCjpsKFJEPRmYKrYdFQkw4iOtB6BkCZBnNY6u56+8sBvw2C1gwhxul3W5GCl8ZRd5vaRLoUfYwPlWSnlegJA4KdrOCr3MVSw=,iv:5phAhgTSHav1bVX8dXlcsMFozO5uAnVtqLT8uO0YtzQ=,tag:MGxpWuX9RtTQnbIYdHohTw==,type:str]
+    lastmodified: "2022-07-25T19:33:11Z"
+    mac: ENC[AES256_GCM,data:FtwLlhtM4/RHou7T15k5G5SaaY7Q8NSyuNqpBNJqp0bjfTqRjsc4ZbjO0/Pv3eowlL5oEs0BhnfyMPMAbHCC5pfP5nNvjIhmMkVet+e0SJSvFqC7vdofcQpobP45H29Z6PB4ixc2qYisCSFKNTV6T6aqklhtgHACJsGKFDfAzBc=,iv:u1GbYcZy+6JspgYJsVkb9tBGq4a1d9Ez4Q052czWVmg=,tag:SsplE03YNgeF57tgAdH6cA==,type:str]
     pgp: []
     unencrypted_suffix: _unencrypted
     version: 3.7.3

--- a/hosts/nyarlathotep/secrets.yaml
+++ b/hosts/nyarlathotep/secrets.yaml
@@ -6,6 +6,9 @@ services:
         env: ENC[AES256_GCM,data:5zHKBFpljPd3d5kv9e1CG3mTsS4H647ysFiui25fdIRv3uDfvrBZxgW+2scQ0GOrhcuLfYgH34ZjBs3eCboNICXiWnXrgQG0AZafoN6vgaf+NjikMPRabylJDE68m+Gg1zJrUx3tX5Ohp01X7zfj81qxvgj/XDyCJ+33n+7nHFTCrv4fuLg8y+58B80V1iZsoL8eDIIJS0sQ7wYSf26uZPAoaGxabc7gvUqzjyuBHlMp+63fSoOo+87kpBKLzntN7b46BJzKocpsO972Qemp5COvxsi14hT8u/57L32tR7+LhB60JfxnPyhBEzAo9lkkGGPDVD64xct8hWjHKj+VsTLpedJg8psh1GngpISEmfEyRfaG8K4mGdpF4CzNtiI7E1tHuCFmNcYDblHX85QfF5XC4CX5Et/3wzZbGBWUgdNGO9kkX0IUmhUDKK5xRVlluQ90Lr9BCjC5lpK5EblgmOydshRTBkG74E0pXt2m6Qm+moWcBfeWYLzwYjt2R5jm8yZy/BNAupq3b0V08flS+jRCC4AOX9tHbc/5teuTnLym152S7ZZyA6y3GR2KYSbf8hF0fqhT2dBTnGAIH0ipzoSkZZHLJ4pUqjD5Y8WCkgddB4+4jolYbh2JFrnGoqw58U4ZG4a97IFhwg/JECLaHiFRBkdbOPy/7brAc/2bjraBRro4fw4U2nRmueL0U1Gs9AFQ61vl6u+Gnb3jh3sWGj5RIM8DgEiA8jQ5g2nq3+H0jdFVhByBGA9RrMDOGbIw5PCPrOrdg2OOitYn4Qdk1p9vFI9JfZUw6PLc+8s+w7fB4VLe8Hk9s7teuRicDhM0meE4Hap5x/Hw3+tNcSXgnXi1vPhC/3gWDTwU6JcepO+iIsdff5e5qf3r6/rNOaNvuFQnWiIC0tXxUwLf0tcnJ3ftr+uogWlTu2jAbhIflVSnvYJKAC973BxlQ2vRc572n1VLFADpO6iFQD+UCYu96tXsbENiK4RoSEYXI1PQoYnOt7rRTvqPaX8REkFk67lvUzH6y4QUcahBIU/wTXDQMxQSPk/d1ofZbbAKfxCjRjRDgw9LXbOgrSCOiqwHYzXa0LujnXkadbQF7l3/5X5LRRMjE7kpdfTSv4Ow5wZ5hK2ZH+DpzfL005c=,iv:VxUWqrsBEl0MzMtypoVCc4X1ZrhbWZYvOkbd/S3Drxo=,tag:6AE0Ucsm6uEQojIFO7xwkw==,type:str]
     bookmarks:
         env: ENC[AES256_GCM,data:VlFj0KFkJDmH80x3tK7tMXTC5Jqtm6TQNWgLdXXsTIMwqEwD6+t33xbFZOKA6hqCqMULWytpjcM=,iv:zy03NVR68LkfpWdr3J6lu8oEGt1buOSEtgTTAG0S+ok=,tag:lz29fKAIUS2FReox8u6SQw==,type:str]
+modules:
+    monitoring_scripts:
+        env: ENC[AES256_GCM,data:VCzUdg6XbkO0MCG9fMQyQdnlkwKnfslpXWgRpPzXu30JAryQGEK0+fggtMTLWgajeCsaxytzt8eClVXZ9yFXHLeUPTMAJ8tvOlPXK/wVurt8B/8v3bsopkxeIDC0vyo7UcJ93u6n67thgw8/GO/jMOCepuMkttilaUbB3pBtHv6uUATAY7u8GizwnfU6Hsg0RHk8ki2pysC+F2Srwa57bGeTVoGpbutslMCw1yfZYrk7zszH0gmBK1tGLQzbGVJKwNH51w==,iv:qnX73ec0GclyseUvNjKDbtPJmiehdPP4Ns4IVj0zpg8=,tag:ziGc4dI834bUVXpy88SXgA==,type:str]
 sops:
     kms: []
     gcp_kms: []
@@ -30,8 +33,8 @@ sops:
             cm5kRU1DeE1MdUdVSnY5L1FQNUE2SFEKnJKjCFW392HIH3CsLhco997rmHBY0XTb
             GwMV2j01l/1y0ItN7JcM0gpMLXPQw36iuKVo5voSkFUgyfTw9/f+FQ==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2022-07-25T18:55:54Z"
-    mac: ENC[AES256_GCM,data:BgABchR8rjELY3uL3jt6gTnC/wJycswy3AhgTibrckUZN+mxbGqabWm7IkaYiYbt5M84H4f0GNEpPsYzPXzzLUgzoWglMoVXve67FzifAW05CvZxQNMi8jC3+fJChQWo8LE4X4iREEI6Y0xHaHNWtRhTnAOGNCvMzWZ4547VZKo=,iv:lvigZO1nxw5py7W7pl85bM+6LJFYSfC6gzGmfqH1ltw=,tag:ev4YiJ7MyYfSR+5W5gb6/w==,type:str]
+    lastmodified: "2022-07-25T19:26:20Z"
+    mac: ENC[AES256_GCM,data:361QQFh0Dut+vl2IaabrvpG/olOQLdsLn2xPwnyYyfyZU6HwKh27kOWPVlF9xzFL7/gQ6EKFmHnhCjpsKFJEPRmYKrYdFQkw4iOtB6BkCZBnNY6u56+8sBvw2C1gwhxul3W5GCl8ZRd5vaRLoUfYwPlWSnlegJA4KdrOCr3MVSw=,iv:5phAhgTSHav1bVX8dXlcsMFozO5uAnVtqLT8uO0YtzQ=,tag:MGxpWuX9RtTQnbIYdHohTw==,type:str]
     pgp: []
     unencrypted_suffix: _unencrypted
     version: 3.7.3

--- a/modules/monitoring-scripts.nix
+++ b/modules/monitoring-scripts.nix
@@ -4,16 +4,26 @@ with lib;
 
 let
   cfg = config.modules.monitoringScripts;
+
+  runScript = cmd: name: source: ''
+    echo "${name}"
+    if ! time ${cmd} "${pkgs.writeText "${name}.monitoring-script" source}" > $OUTFILE; then
+      echo "Failure:"
+      cat $OUTFILE
+      aws sns publish --topic-arn "$TOPIC_ARN" --subject "Alert: ${config.networking.hostName}" --message "file://''${OUTFILE}"
+    fi
+  '';
 in
 {
   options = {
     modules = {
       monitoringScripts = {
-        enable = mkOption { type = types.bool; default = true; };
-        onCalendar = mkOption { type = types.str; default = "monthly"; };
-        scriptDirectory = mkOption { type = types.path; default = "/home/barrucadu/monitoring-scripts"; };
-        scriptUser = mkOption { type = types.str; default = "barrucadu"; };
-        scriptGroup = mkOption { type = types.str; default = "users"; };
+        enable = mkOption { type = types.bool; default = false; };
+        scripts = mkOption { type = types.attrsOf types.str; default = { }; };
+        environmentFile = mkOption { type = types.str; };
+        onCalendar = mkOption { type = types.str; default = "hourly"; };
+        user = mkOption { type = types.str; default = "barrucadu"; };
+        group = mkOption { type = types.str; default = "users"; };
       };
     };
   };
@@ -21,17 +31,25 @@ in
   config = mkIf cfg.enable {
     systemd.timers.monitoring-scripts = {
       wantedBy = [ "timers.target" ];
-      timerConfig = {
-        OnCalendar = cfg.onCalendar;
-      };
+      timerConfig.OnCalendar = cfg.onCalendar;
     };
 
     systemd.services.monitoring-scripts = {
       description = "Run monitoring scripts";
-      serviceConfig.WorkingDirectory = cfg.scriptDirectory;
-      serviceConfig.ExecStart = "${pkgs.zsh}/bin/zsh --login -c ./monitor.sh";
-      serviceConfig.User = cfg.scriptUser;
-      serviceConfig.Group = cfg.scriptGroup;
+      path = with pkgs; [ awscli bash zfs ];
+      serviceConfig = {
+        ExecStart = pkgs.writeShellScript "monitoring.sh" ''
+          set -e
+
+          OUTFILE=`mktemp`
+          trap "rm $OUTFILE" EXIT
+
+          ${concatStringsSep "\n" (mapAttrsToList (runScript "bash -e -o pipefail") cfg.scripts)}
+        '';
+        EnvironmentFile = cfg.environmentFile;
+        User = cfg.user;
+        Group = cfg.group;
+      };
     };
   };
 }

--- a/modules/zfs-automation.nix
+++ b/modules/zfs-automation.nix
@@ -33,7 +33,7 @@ in
     services.zfs.autoSnapshot.enable = true;
     services.zfs.autoSnapshot.monthly = 3;
 
-    modules.monitoringScripts.scripts.zfs = ''
+    services.monitoring.scripts.zfs = ''
       if [[ "$(zpool status -x)" != "all pools are healthy" ]]; then
         zpool status
         exit 1

--- a/modules/zfs-automation.nix
+++ b/modules/zfs-automation.nix
@@ -32,5 +32,12 @@ in
     # in practice.
     services.zfs.autoSnapshot.enable = true;
     services.zfs.autoSnapshot.monthly = 3;
+
+    modules.monitoringScripts.scripts.zfs = ''
+      if [[ "$(zpool status -x)" != "all pools are healthy" ]]; then
+        zpool status
+        exit 1
+      fi
+    '';
   };
 }

--- a/services/monitoring.nix
+++ b/services/monitoring.nix
@@ -3,7 +3,7 @@
 with lib;
 
 let
-  cfg = config.modules.monitoringScripts;
+  cfg = config.services.monitoring;
 
   runScript = cmd: name: source: ''
     echo "${name}"
@@ -16,8 +16,8 @@ let
 in
 {
   options = {
-    modules = {
-      monitoringScripts = {
+    services = {
+      monitoring = {
         enable = mkOption { type = types.bool; default = false; };
         scripts = mkOption { type = types.attrsOf types.str; default = { }; };
         environmentFile = mkOption { type = types.str; };


### PR DESCRIPTION
This PR does for my monitoring-scripts repository what #109 and #114 did for my backup-scripts repository: pull it into this repo, improve it, and fully retire the old repo.