### PR TITLE
[nyarlathotep] Import DNS config

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1660496378,
-        "narHash": "sha256-sgAhmrC1iSnl5T2VPPiMpciH1aRw5c7PYEdXX6jd6Gk=",
+        "lastModified": 1661700591,
+        "narHash": "sha256-NZa+z+TJC+Hk+87+LKkjFFmBn4GyMVEPcWFXFU+aTkU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "879121648fe522b38cc1cf75aef160a14a1f2e7b",
+        "rev": "16236dd7e33ba4579ccd3ca8349396b2f9c960fe",
         "type": "github"
       },
       "original": {

--- a/hosts/nyarlathotep/secrets.yaml
+++ b/hosts/nyarlathotep/secrets.yaml
@@ -8,6 +8,11 @@ services:
         env: ENC[AES256_GCM,data:VlFj0KFkJDmH80x3tK7tMXTC5Jqtm6TQNWgLdXXsTIMwqEwD6+t33xbFZOKA6hqCqMULWytpjcM=,iv:zy03NVR68LkfpWdr3J6lu8oEGt1buOSEtgTTAG0S+ok=,tag:lz29fKAIUS2FReox8u6SQw==,type:str]
     monitoring:
         env: ENC[AES256_GCM,data:GEY5igFPmgxdH8l6rB7Dz3iFXxLb3BPIPRk1Cd66DzJcGhMVwJxoFFvEUMQF4nKNVzkG/mxuBg7xSpZoEn4xugmIaFpJWd2rfM44Ku5+v6Y3TyKL/crQKR/0ryHHaTL39etXu84k8+GhxH7n5E8iwNdMyEkcFCNfdTnrUZaxzfRWGIJfzqq1usJ0uOSlZxIR/S/ONz0b2ShaqSfsm+m1mgPjnnNuUH5UzPNJ4A1Vfjchbi4sdOE/o5C3Vx2RUeEW3DQ6wA==,iv:/9OKazABBXn/OUCw5r/I2pMOwAk47rBcCT32neSsZFY=,tag:f9cxttlvhKJgLphzQg1gkg==,type:str]
+    resolved:
+        zones:
+            10.in-addr.arpa: ENC[AES256_GCM,data:JfNxQqz8nPSX8XrWUs8dePEldi55Z528ihMPqxfsK/J46V31SVTqSOpHlrfBB2NDvxGVZTo1l8o+6jIv+x7yWQQg3YLD5Wtlm4VHNEJ4x+hRMjmMVkNAb9Skj0UaQTPBvSkCbuitmnwd/Ga3jf44Ekdmuv0cYBdwiwEEqlCjO2UWZVWiDOtXl5BTSTXn5W0rrpdrFlxUkv/+D/dvK4mLGbO/WdIQjbzVLfh8qlqPUgNjyXacR2ui+NZYbauV48zXMoV7COSP,iv:eL1oYIqu2abNxWNqZaTqgu1QrHqwCgFXnpv8tF9k7+w=,tag:m6IDyggBUF+RZgZXO5vUDA==,type:str]
+            blocked: ENC[AES256_GCM,data:Qzb9HwMCAzeWDjBRxzb+2+/BP68JZnAsUoVR5CkkRef+x7+4ipYo/opljs1RnZHuMRHLiBUuQkEu656TdGdGob8DHcZ1/exGknHHuYtAUZa/KG5xADJvOcFHITJQRzvb466kofJ/1Ly1/oYmVZv/9M/353j1dBrEwN+6NAlAsKOD9GUQ6J+0Tbx798metPqy9ZzwATnLSjElA+/ueaw5mA6EUN/38SPAQYKeqhJLpwEh1nccniLdMieMKj4ehVm1F3fmjhvQN6wPUtQV8dFKRkHVv03hf1/ImXO7nuD0ZkugFeTAastqIo9Y1E2of6SO3RRoZpzEtvt++WHHEDRxmbkrnaOS61scPN59GPdaZ9ytLPg7Hoon76ta+hH/wL7XKTlX3B+/SnUCd1Dfe95XlJgz+dzQ3LorevOs3ZgU/7+fOvBrKLLQi0V0UrMZHVixRaumuLLO6NQ=,iv:iiThbHRuTC8yof7ofNqDu/i9rcnF1JQB/uhBRcrmMBQ=,tag:EvuQbsYsELgnhvSO94HVKg==,type:str]
+            lan: ENC[AES256_GCM,data:ScybUX8jI96imBHOx2KIT3I3Z+ZiRe27zMcGZ2NLbV+J36iZRfdftzPV1ardxEt2cgFzeCostXYxCVFOO9/NHzHM451a6ubhtjxGTBav+9DNoEFgBez5JzB1Qkmf7tBSxvxhFC/7WTkWCAc/Y/DJ9lzcsUNjc2qX8XXQ3lqUbGzK7Qw8jIf4+mxAV0EVMt/U/8IQru62t4HxvKEnHE6/XjgmJFB8nTipnmPwplQN1xOs3BDWIMEgpARzDMAHFM4f4IX6Mg65EuYhM8Dmikl4EfvHWKzPfNSK4nVSL+u0FNzLyjJ81c4x1SgkX7r9zolxqGZ407eRBFVS/Hf00LoGrHOiszSXjp3MlXAoVFg4SIuyvNjhZMDX8RoLbZ7OmPi95E3KnLTf8mInheZE88o2lKoOuDN6MiIK2/zPKYBZ7CPuIevtmsSPuSfNS0ixHcrHEZK6fxtqUX4wZOYh7oMH/P0PQ7oaD8m1ijd+rjupLt0cixLzvnfnhwuGnwyastuRtF8C5Q==,iv:wrr15qEP/xg9/m80NqLeRlNc/GHjjQB5tUH0Msq3md4=,tag:hMvJqvwHPke265lZjI1ZFg==,type:str]
 sops:
     kms: []
     gcp_kms: []
@@ -32,8 +37,8 @@ sops:
             cm5kRU1DeE1MdUdVSnY5L1FQNUE2SFEKnJKjCFW392HIH3CsLhco997rmHBY0XTb
             GwMV2j01l/1y0ItN7JcM0gpMLXPQw36iuKVo5voSkFUgyfTw9/f+FQ==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2022-07-26T10:51:33Z"
-    mac: ENC[AES256_GCM,data:9Lob4cWXFnYOEDt1IOxwhaLqX8d3mz6HLc5fFR+H9ojwg7LfoUAsS5v3wiYLHympRMW0deV0qVFdieSuevhQmIk5SpJHmjTn4JND+RRvp0ynikyzpVzNQZmvItO2k4KZCvtHJx76cM7cVS6YABzo5s8XRIMXLztoQRYfekEy7kI=,iv:4+AQsgyzInMPCpizCJFLf9xdDdWHqYdjmHRr6NBFD10=,tag:C8EBv1W/hG5Tr4rQ/NqkGQ==,type:str]
+    lastmodified: "2022-08-29T19:27:49Z"
+    mac: ENC[AES256_GCM,data:EsJZuVFBnWmrPUAfecoZ+ROr1JSEqIQrBpmOHIl5ERWB7641hfZ9excjps5WdgRjRosUCLRpOqNS9A3bDbFqf2ywJkgbGvN4j2l1OBzsbYVm9VuCj5CA4lAenhRbgBMhbIo5W2+2RfbBBM3V+VqaFa4HqJtX9Pm1fw7wtKj09Xw=,iv:lPonBbbN4M3GGLAzGmgdwfDttxUq52F1/cW/DtBfLck=,tag:TuR+ENijTCrTaYsZrscTOA==,type:str]
     pgp: []
     unencrypted_suffix: _unencrypted
     version: 3.7.3


### PR DESCRIPTION
Previously, this was done by unmanaged (but backed-up) files in
`/persist`.  But now that the default config is taken straight from
the resolved source (5ab0007), only the custom config needs to be
managed.

Custom zones I've added to the secrets (though it's more "private"
than "secret") and the StevenBlack blocklist I just fetch from the
source.  Yes, this does impose a new external dependency on this repo,
but the chances of it disappearing seem pretty slim, and I can just
remove it if that does happen.  The alternative was committing ~6MB of
hosts file, which felt a bit excessive.