### PR TITLE
Fix auto-upgrades

### DIFF
--- a/common.nix
+++ b/common.nix
@@ -59,6 +59,7 @@ in
     system.autoUpgrade.enable = true;
     system.autoUpgrade.allowReboot = true;
     system.autoUpgrade.flags = [ "--update-input" "nixpkgs" ];
+    system.autoUpgrade.flake = "/etc/nixos";
     system.autoUpgrade.dates = "06:45";
 
     #############################################################################

--- a/modules/erase-your-darlings.nix
+++ b/modules/erase-your-darlings.nix
@@ -60,6 +60,9 @@ in
 
     systemd.services.prometheus.serviceConfig.BindPaths = "${toString cfg.persistDir}/var/lib/${config.services.prometheus.stateDir}:/var/lib/${config.services.prometheus.stateDir}";
 
+    # Needs real path, not a symlink
+    system.autoUpgrade.flake = mkForce "${cfg.persistDir}/etc/nixos";
+
     services.caddy.dataDir = "${toString cfg.persistDir}/var/lib/caddy";
     services.dockerRegistry.storagePath = "${toString cfg.persistDir}/var/lib/docker-registry";
     services.syncthing.dataDir = "${toString cfg.persistDir}/var/lib/syncthing";


### PR DESCRIPTION
Need to set the `system.autoUpgrade.flake` parameter, or it tries to
use the old CLI.

Yes, this has been broken since July - I've just been occasionally
updating my systems by hand since then.