### PR TITLE
Bump concourse baggageclaim timeout to 30m

### DIFF
--- a/services/concourse.nix
+++ b/services/concourse.nix
@@ -37,6 +37,7 @@ in
         "CONCOURSE_GARDEN_LOG_LEVEL" = "error";
         "CONCOURSE_PROMETHEUS_BIND_IP" = "0.0.0.0";
         "CONCOURSE_PROMETHEUS_BIND_PORT" = "8088";
+        "CONCOURSE_BAGGAGECLAIM_RESPONSE_HEADER_TIMEOUT" = "30m";
       };
       environmentFiles = [ cfg.environmentFile ];
       extraOptions = [ "--network=concourse_network" ];


### PR DESCRIPTION
Sometimes, after restarting, it repeatedly hits the 10m timeout.  Only seems to happen with the memo builder, so I wonder if there's something up with that image.