### PR TITLE
Increase pleroma postgres `/dev/shm` size

### DIFF
--- a/shared/pleroma/default.nix
+++ b/shared/pleroma/default.nix
@@ -61,7 +61,10 @@ in
         "POSTGRES_USER" = "pleroma";
         "POSTGRES_PASSWORD" = "pleroma";
       };
-      extraOptions = [ "--network=pleroma_network" ];
+      extraOptions = [
+        "--network=pleroma_network"
+        "--shm-size=1g"
+      ];
       volumes = [ "${toString cfg.dockerVolumeDir}/pgdata:/var/lib/postgresql/data" ];
     };
     systemd.services."${backend}-pleroma-db".preStart = "${backend} network create -d bridge pleroma_network || true";


### PR DESCRIPTION
This is so it's possible to run a `VACUUM ANALYZE` from time to time.
Possible future work: add a maintenance task to do that.