### PR TITLE
Add an abstraction over raw oci-containers

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1667125965,
-        "narHash": "sha256-z/OLvPwIhwdN9J+ED/0rPz/Wh/0sPuvczURwsiEENSQ=",
+        "lastModified": 1667653703,
+        "narHash": "sha256-Xow4vx52/g5zkhlgZnMEm/TEXsj+13jTPCc2jIhW1xU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "26eb67abc9a7370a51fcb86ece18eaf19ae9207f",
+        "rev": "f09ad462c5a121d0239fde645aacb2221553a217",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -80,7 +80,7 @@
           pkgs.writeShellScriptBin "lint.sh" ''
             #!${pkgs.bash}
 
-            PATH=${pkgs.findutils}/bin:${pkgs.nix-linter}/bin:${pkgs.shellcheck}/bin
+            PATH=${pkgs.findutils}/bin:${pkgs.nix-linter}/bin:${pkgs.shellcheck}/bin:${pkgs.git}/bin:${pkgs.gnugrep}/bin
 
             ${pkgs.lib.fileContents ./scripts/lint.sh}
           '';

--- a/hosts/carcosa/configuration.nix
+++ b/hosts/carcosa/configuration.nix
@@ -323,7 +323,6 @@ in
   # bookdb
   nixfiles.bookdb.enable = true;
   nixfiles.bookdb.image = "registry.barrucadu.dev/bookdb:latest";
-  nixfiles.bookdb.pullOnStart = true;
   nixfiles.bookdb.registry = registryBarrucaduDev;
   nixfiles.bookdb.baseURI = "https://bookdb.barrucadu.co.uk";
   nixfiles.bookdb.readOnly = true;
@@ -332,7 +331,6 @@ in
   # bookmarks
   nixfiles.bookmarks.enable = true;
   nixfiles.bookmarks.image = "registry.barrucadu.dev/bookmarks:latest";
-  nixfiles.bookmarks.pullOnStart = true;
   nixfiles.bookmarks.registry = registryBarrucaduDev;
   nixfiles.bookmarks.baseURI = "https://bookmarks.barrucadu.co.uk";
   nixfiles.bookmarks.readOnly = true;

--- a/hosts/lainonlife/configuration.nix
+++ b/hosts/lainonlife/configuration.nix
@@ -229,7 +229,6 @@ in
   # Pleroma
   nixfiles.pleroma.enable = true;
   nixfiles.pleroma.image = "registry.barrucadu.dev/pleroma:latest";
-  nixfiles.pleroma.pullOnStart = true;
   nixfiles.pleroma.registry = {
     username = "registry";
     passwordFile = config.sops.secrets."nixfiles/pleroma/docker_registry".path;
@@ -237,8 +236,8 @@ in
   };
   nixfiles.pleroma.domain = "social.lainon.life";
   nixfiles.pleroma.faviconPath = ./pleroma-favicon.png;
-  nixfiles.pleroma.dockerVolumeDir = "/persist/docker-volumes/pleroma";
   nixfiles.pleroma.secretsFile = config.sops.secrets."nixfiles/pleroma/exc".path;
+  nixfiles.oci-containers.volumeBaseDir = "/persist/docker-volumes";
   # TODO: figure out how to lock this down so only the pleroma process
   # can read it (remap the container UID / GID to something known,
   # perhaps?)

--- a/hosts/nyarlathotep/configuration.nix
+++ b/hosts/nyarlathotep/configuration.nix
@@ -5,8 +5,6 @@ with lib;
 let
   shares = [ "anime" "manga" "misc" "music" "movies" "tv" "images" "torrents" ];
 
-  ociBackend = config.virtualisation.oci-containers.backend;
-
   bookdbPort = 3000;
   floodPort = 3001;
   finderPort = 3002;
@@ -554,22 +552,20 @@ in
     };
   };
 
-  virtualisation.oci-containers.containers.promscale = {
-    autoStart = true;
+  nixfiles.oci-containers.containers.promscale = {
     image = "timescale/promscale:latest";
     cmd = [ "-db.host=promscale-db" "-db.name=postgres" "-db.password=promscale" "-db.ssl-mode=allow" "-web.enable-admin-api=true" "-metrics.promql.lookback-delta=168h" ];
-    extraOptions = [ "--network=promscale_network" ];
     dependsOn = [ "promscale-db" ];
-    ports = [ "127.0.0.1:${toString promscalePort}:9201" ];
+    network = "promscale_network";
+    ports = [{ host = promscalePort; inner = 9201; }];
   };
-  virtualisation.oci-containers.containers.promscale-db = {
-    autoStart = true;
+  nixfiles.oci-containers.containers.promscale-db = {
     image = "timescaledev/promscale-extension:latest-ts2-pg14";
     environment = {
       POSTGRES_PASSWORD = "promscale";
     };
-    extraOptions = [ "--network=promscale_network" ];
-    volumes = [ "/persist/docker-volumes/promscale/pgdata:/var/lib/postgresql/data" ];
+    network = "promscale_network";
+    volumes = [{ name = "pgdata"; inner = "/var/lib/postgresql/data"; }];
+    volumeSubDir = "promscale";
   };
-  systemd.services."${ociBackend}-promscale-db".preStart = "${ociBackend} network create -d bridge promscale_network || true";
 }

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -4,3 +4,7 @@ nix-linter -r .
 
 # SC2001: use pattern expansion over sed
 find . -name '*.sh' -print0 | xargs -0 -n1 shellcheck -s bash -e SC2001
+
+if git grep 'virtualisation.oci-containers' | grep -vE 'scripts/lint.sh|shared/oci-containers/'; then
+    exit 1
+fi

--- a/shared/default.nix
+++ b/shared/default.nix
@@ -26,6 +26,7 @@ in
     ./finder
     ./foundryvtt
     ./minecraft
+    ./oci-containers
     ./pleroma
     ./resolved
     ./umami
@@ -180,7 +181,6 @@ in
     # Use docker for all the OCI container based services
     virtualisation.docker.enable = true;
     virtualisation.docker.autoPrune.enable = true;
-    virtualisation.oci-containers.backend = "docker";
 
     #############################################################################
     ## Dashboards & Alerting

--- a/shared/erase-your-darlings/default.nix
+++ b/shared/erase-your-darlings/default.nix
@@ -64,14 +64,8 @@ in
     services.syncthing.dataDir = "${toString cfg.persistDir}/var/lib/syncthing";
 
     # my services
-    nixfiles.bookdb.dockerVolumeDir = "${toString cfg.persistDir}/docker-volumes/bookdb";
-    nixfiles.bookmarks.dockerVolumeDir = "${toString cfg.persistDir}/docker-volumes/bookmarks";
-    nixfiles.concourse.dockerVolumeDir = "${toString cfg.persistDir}/docker-volumes/concourse";
-    nixfiles.finder.dockerVolumeDir = "${toString cfg.persistDir}/docker-volumes/finder";
     nixfiles.foundryvtt.dataDir = "${toString cfg.persistDir}/srv/foundry";
     nixfiles.minecraft.dataDir = "${toString cfg.persistDir}/srv/minecraft";
-    nixfiles.pleroma.dockerVolumeDir = "${toString cfg.persistDir}/docker-volumes/pleroma";
-    nixfiles.umami.dockerVolumeDir = "${toString cfg.persistDir}/docker-volumes/umami";
-    nixfiles.wikijs.dockerVolumeDir = "${toString cfg.persistDir}/docker-volumes/wikijs";
+    nixfiles.oci-containers.volumeBaseDir = "${toString cfg.persistDir}/docker-volumes";
   };
 }

--- a/shared/oci-containers/default.nix
+++ b/shared/oci-containers/default.nix
@@ -1,0 +1,79 @@
+{ config, lib, ... }:
+
+with lib;
+let
+  mkPreStart = _name: container: concatStringsSep "\n" [
+    (if container.pullOnStart then "${cfg.backend} pull ${container.image}" else "")
+    (if container.network != null then "${cfg.backend} network create -d bridge ${container.network} || true" else "")
+  ];
+
+  mkPortDef = { host, inner }: "127.0.0.1:${toString host}:${toString inner}";
+
+  mkVolumeDef = container: { name, host, inner }:
+    if host != null
+    then "${host}:${inner}"
+    else "${cfg.volumeBaseDir}/${container.volumeSubDir}/${name}:${inner}";
+
+  mkContainer = _name: container: with container; {
+    inherit autoStart cmd dependsOn environment environmentFiles image login;
+    extraOptions =
+      container.extraOptions ++
+      (if container.network != null then [ "--network=${container.network}" ] else [ ]);
+    ports = map mkPortDef ports;
+    volumes = map (mkVolumeDef container) volumes;
+  };
+
+  portOptions = {
+    options = {
+      host = mkOption { type = types.int; };
+      inner = mkOption { type = types.int; };
+    };
+  };
+
+  volumeOptions = {
+    options = {
+      name = mkOption { type = types.nullOr types.str; default = null; };
+      host = mkOption { type = types.nullOr types.str; default = null; };
+      inner = mkOption { type = types.str; };
+    };
+  };
+
+  cfg = config.nixfiles.oci-containers;
+in
+{
+  options.nixfiles.oci-containers = {
+    backend = mkOption { type = types.str; default = "docker"; };
+    containers = mkOption {
+      type = types.attrsOf (types.submodule ({ name, ... }: {
+        options = {
+          /* regular oci-containers */
+          autoStart = mkOption { type = types.bool; default = true; };
+          cmd = mkOption { type = types.listOf types.str; default = [ ]; };
+          dependsOn = mkOption { type = types.listOf types.str; default = [ ]; };
+          environment = mkOption { type = types.attrsOf types.str; default = { }; };
+          environmentFiles = mkOption { type = types.listOf types.path; default = [ ]; };
+          extraOptions = mkOption { type = types.listOf types.str; default = [ ]; };
+          image = mkOption { type = types.str; };
+          login.username = mkOption { type = types.nullOr types.str; default = null; };
+          login.passwordFile = mkOption { type = types.nullOr types.str; default = null; };
+          login.registry = mkOption { type = types.nullOr types.str; default = null; };
+          /* changed */
+          ports = mkOption { type = types.listOf (types.submodule portOptions); default = [ ]; };
+          volumes = mkOption { type = types.listOf (types.submodule volumeOptions); default = [ ]; };
+          /* new options */
+          pullOnStart = mkOption { type = types.bool; default = true; };
+          network = mkOption { type = types.nullOr types.str; default = null; };
+          volumeSubDir = mkOption { type = types.str; default = name; };
+        };
+      }));
+      default = { };
+    };
+    volumeBaseDir = mkOption { type = types.str; };
+  };
+
+  config = {
+    virtualisation.oci-containers.backend = cfg.backend;
+    virtualisation.oci-containers.containers = mapAttrs mkContainer cfg.containers;
+    systemd.services = mapAttrs' (name: value: nameValuePair "${cfg.backend}-${name}" { preStart = mkPreStart name value; }) cfg.containers;
+  };
+}

--- a/shared/umami/default.nix
+++ b/shared/umami/default.nix
@@ -3,12 +3,11 @@
 with lib;
 let
   cfg = config.nixfiles.umami;
-  backend = config.virtualisation.oci-containers.backend;
+  backend = config.nixfiles.oci-containers.backend;
 in
 {
   options.nixfiles.umami = {
     enable = mkOption { type = types.bool; default = false; };
-    dockerVolumeDir = mkOption { type = types.path; };
     port = mkOption { type = types.int; default = 3000; };
     postgresTag = mkOption { type = types.str; default = "13"; };
     umamiTag = mkOption { type = types.str; default = "postgresql-latest"; };
@@ -16,30 +15,28 @@ in
   };
 
   config = mkIf cfg.enable {
-    virtualisation.oci-containers.containers.umami = {
-      autoStart = true;
+    nixfiles.oci-containers.containers.umami = {
       image = "ghcr.io/mikecao/umami:${cfg.umamiTag}";
       environment = {
         "DATABASE_URL" = "postgres://umami:umami@umami-db/umami";
       };
       environmentFiles = [ cfg.environmentFile ];
-      extraOptions = [ "--network=umami_network" ];
       dependsOn = [ "umami-db" ];
-      ports = [ "127.0.0.1:${toString cfg.port}:3000" ];
+      network = "umami_network";
+      ports = [{ host = cfg.port; inner = 3000; }];
     };
 
-    virtualisation.oci-containers.containers.umami-db = {
-      autoStart = true;
+    nixfiles.oci-containers.containers.umami-db = {
       image = "postgres:${cfg.postgresTag}";
       environment = {
         "POSTGRES_DB" = "umami";
         "POSTGRES_USER" = "umami";
         "POSTGRES_PASSWORD" = "umami";
       };
-      extraOptions = [ "--network=umami_network" ];
-      volumes = [ "${toString cfg.dockerVolumeDir}/pgdata:/var/lib/postgresql/data" ];
+      network = "umami_network";
+      volumes = [{ name = "pgdata"; inner = "/var/lib/postgresql/data"; }];
+      volumeSubDir = "umami";
     };
-    systemd.services."${backend}-umami-db".preStart = "${backend} network create -d bridge umami_network || true";
 
     nixfiles.backups.scripts.umami = ''
       ${backend} exec -i umami-db pg_dump -U umami --no-owner umami | gzip -9 > dump.sql.gz


### PR DESCRIPTION
Adds a few useful behaviours.

Config:

- Auto-start
- Add param to join network
- Map named volumes to filesystem mounts
- Bind all ports to `127.0.0.1`

Pre-start:

- Pull the image (useful for `:latest` images)
- Create the network