### PR TITLE
Remove boto3 from duplicity PYTHONPATH

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -64,14 +64,10 @@
 
       packages.${system} = {
         backups =
-          let
-            pythonEnv = pkgs.python3.buildEnv.override { extraLibs = with pkgs.python3Packages; [ boto3 ]; };
-          in
           pkgs.writeShellScriptBin "backups.sh" ''
             #!${pkgs.bash}
 
-            PATH=${pkgs.duplicity}/bin:${pkgs.python3}/bin:${pkgs.sops}/bin:${pkgs.nettools}/bin
-            PYTHONPATH="${pythonEnv}/${pkgs.python3.sitePackages}/"
+            PATH=${pkgs.duplicity}/bin:${pkgs.sops}/bin:${pkgs.nettools}/bin
 
             ${pkgs.lib.fileContents ./scripts/backups.sh}
           '';

--- a/shared/backups/default.nix
+++ b/shared/backups/default.nix
@@ -64,10 +64,6 @@ let
     systemd
   ];
 
-  servicePythonPath =
-    let penv = pkgs.python3.buildEnv.override { extraLibs = with pkgs.python3Packages; [ boto3 ]; };
-    in "${penv}/${pkgs.python3.sitePackages}/";
-
   serviceConfig = type: {
     ExecStart = "${script} ${type}";
     EnvironmentFile = cfg.environmentFile;
@@ -101,14 +97,12 @@ in
     systemd.services.backup-scripts-full = {
       description = "Take a full backup";
       path = servicePath;
-      environment.PYTHONPATH = servicePythonPath;
       serviceConfig = serviceConfig "full";
     };
 
     systemd.services.backup-scripts-incr = {
       description = "Take an incremental backup";
       path = servicePath;
-      environment.PYTHONPATH = servicePythonPath;
       serviceConfig = serviceConfig "incr";
     };
   };


### PR DESCRIPTION
This isn't needed, the package now depends on boto3 by default.