### PR TITLE
Switch to standard Pleroma module

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1675600654,
-        "narHash": "sha256-ipsDTkzRq1CAl2g5tYd7ugjVMSKF6KLh9F+5Kso0lT0=",
+        "lastModified": 1675681488,
+        "narHash": "sha256-0E/oYpixC+joFk7UrY60TwZcdthzP2BXmJwne3Ni8ZI=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "cff83d5032a21aad4f69bf284e95b5f564f4a54e",
+        "rev": "13fdd3945d8a2da5e4afe35d8a629193a9680911",
         "type": "github"
       },
       "original": {
@@ -32,9 +32,26 @@
         "type": "github"
       }
     },
+    "nixpkgs-unstable": {
+      "locked": {
+        "lastModified": 1675673983,
+        "narHash": "sha256-8hzNh1jtiPxL5r3ICNzSmpSzV7kGb3KwX+FS5BWJUTo=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "5a350a8f31bb7ef0c6e79aea3795a890cf7743d4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
         "nixpkgs": "nixpkgs",
+        "nixpkgs-unstable": "nixpkgs-unstable",
         "sops-nix": "sops-nix"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -1,16 +1,18 @@
 {
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-22.11";
+    nixpkgs-unstable.url = "github:NixOS/nixpkgs/nixos-unstable";
     sops-nix = {
       url = "github:Mic92/sops-nix";
       inputs.nixpkgs.follows = "nixpkgs";
     };
   };
 
-  outputs = { nixpkgs, sops-nix, ... }@flakeInputs:
+  outputs = { nixpkgs, sops-nix, nixpkgs-unstable, ... }@flakeInputs:
     let
       system = "x86_64-linux";
       pkgs = import nixpkgs { inherit system; };
+      pkgsUnstable = import nixpkgs-unstable { inherit system; };
     in
     {
       formatter.${system} = pkgs.nixpkgs-fmt;
@@ -19,7 +21,7 @@
         let
           mkNixosConfiguration = name: extraModules: nixpkgs.lib.nixosSystem {
             inherit system;
-            specialArgs = { inherit flakeInputs; };
+            specialArgs = { inherit flakeInputs pkgsUnstable; };
             modules = [
               ./shared
               # nix-linter doesn't support the ./hosts/${name}/foo.nix syntax yet

--- a/hosts/lainonlife/secrets.yaml
+++ b/hosts/lainonlife/secrets.yaml
@@ -2,7 +2,6 @@ nixfiles:
     backups:
         env: ENC[AES256_GCM,data:nmYq+9RyW77EhxYqEo6q0084lCWOT7OcFhAOsSeUwPcMw/vuJZmzgrCOv5zCO2+9sRbk26wkbLALXNXvbGV+nbyieOmXu4HJ6y9lpV+fsxpUC+nWQbxeVhxk/LInvhw7xwLINAgCRJZZ2ZgnTuKbHms9NnsohClU9VfPSXbrx/qgfgvBBXwoCxnooD9xHZaJOiC9Q3nqme7yYzxudJpeO5YJNfLnYn4WQ3An+MGNT1Vk2DUVzCKG5CautPT6VJp0iHMIKNS8GmUKY7KYlTJS6balA/oX8KaovwM/DPkD7p0Yk5LSXm0DtvihIXc9Bck0rWiqd6FgtGZhrA6VpIQaX3cuyE1jugvu/d2y20UPX+qc3ztF8VjterVU1xidPi3TRlqBW615fjawK0JJjAY+/jbjnSE2S0ughh7DZ6/n8cpPBymetqLY2gdeRqGNtfdMoyTZhWq+Zjd6v5vRliRLsd4R7Zpnglt2PJyqInY2Ti3SVoxzMlQDNetPqY/+vppjMw7pFwOL+cWZxBDWoiH77Cx9GKiXM9tP2HO1zibAg82ZxG8llkPlSRaFBEmnK8SZGy9wN0zRzwcCl3WAqYl3TF4o+HOzkJ0+4haPtOAgdakXup+E0sxrrFTQb+1h43LPWdfjbbEbtc+wNqFt1JrOaFS9LJ1Cs7Wa5n9tG7LjKOqBfx0PyNp1HH1kxezDnu2MNHoBP2l6H/0lkkidtrw8bj6HzQuoE8DQ3oFqEdyag60KLgoVNzqfDbw9Q+O0j1u7hgAu/itBdqY0bB020Pb4elJOs4QJqc4YRNFvm34JEDW+ZZLPVzEfNRliw1jRNWwVP15GkbMHPGFI5zmz/OOQ4YRNitvk9QPQZZ3wEyGgzWwez2nrh+l/CmY1QhHUMcoEZ+Xs7YmYCUhtNoP/RAQVrv693cYtdjy6bNv+NEMPPazkG8ek1Fsb1dog4GiQYg4bMg==,iv:BSW9y8qHtkI6CTxlvTFGa2s8LP4OEYJYuDggqlU7P7Y=,tag:HazvHxVO+cHDDrGID3Ui9A==,type:str]
     pleroma:
-        docker_registry: ENC[AES256_GCM,data:AzA5Gf+NOfcelN/tziHL4RFs9xfSg//MXYnj9evH+9VzWdiA,iv:/TFvRTDfyfPA7+96C4EmHsvI9sFFutsE2kXxz/M81X0=,tag:kVHFM+4PC0NBIiGATqhL7Q==,type:str]
         exc: ENC[AES256_GCM,data:Kg5cima/aox+VptUNn0jN6vu4M0/cMfR4f2EL9PUFsAM83lDwtrArZHyIYOflnzmmTITXboEiGgtnjSqRFuRwc/1vjwypZt98qLUUHVoEY4WMzvIq2OkWOJH5CIHzoBjKVDEMoBrBRrXUxjTcsRO4jTtGnZ0dWx8r9eP4W4sIA3NV+Hm6ai1yVz2Fjw59ibMyzFNVi2p0tu1Gr8eSKq8+vTM5grVShTK1W/4ADvhxyL0C8c1QQtJOBZPzObWpdrQNF7GTlKn3+ABYqSMZji8hcnQmmZJbdnZ//hBEGKV1Ln/Sye8X4U9D3X0gOl24ZasU9VOl0O4kNuMKd/+TaBcbEVSHZS0CiAl7R6tW8+kJ+PhoL1ZOcZV4xsSji5JjTDo+LiublOh2r9pACDRGYr+JwAoHI91zH+sqJ3U8Vkf9ZCOnGet/XaNwq5l3u/iGrsmgWWd7ITP7LMhobVlx2JRm0xllzs2RL64MJ84BEIJ7z7EPNBlThhKK44Cl7A=,iv:0OxR1PiPFEGHI7W3n7UUibwg9SMCkvnTDJ/nSNJkqX8=,tag:VOof5nXReWQnpaxIlFr7fg==,type:str]
 services:
     fallback:
@@ -41,8 +40,8 @@ sops:
             djcrQ1VPeWo2MWVhMEZ2Y0hDRGhEN28Kz3hO6EUIOqF1atszAKMV57GIuXD12No/
             AxJlFzafGaKZA+c787nVcTk+y5gDi2Rpejhl6X+BgjCVa91zuC6B/Q==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2022-10-07T16:23:04Z"
-    mac: ENC[AES256_GCM,data:yaif4k0Z69rPenL6wIuftIBKaPZPsr93xtTm4DNm/QNTZuMcAUBoKF3Ox5B1LwS7lg0WgPYoukQtlePAqmXTYgdRTJtx+4Lgg5i9tZooC/tZZeKkG7rdrEHsdwcT6aV2Van3/YhBxuQm1NKxoc0mlZM0raiedjVB9zB1T8w7x8k=,iv:OFyeP4TlIPFJe8tQg0pkTJktVHsot3BUFRVOemHxOsY=,tag:vwgdFOXRMZNxs1ulDfewPw==,type:str]
+    lastmodified: "2023-02-08T00:52:13Z"
+    mac: ENC[AES256_GCM,data:i9SL10e0+qN3QPIozyezxOMJFfSYk3McRW2CrTXIGk9NgFLTE6NpHYzPMKXcwKTtoQeRX/8R9aYRFOnZSc1tsTBb3YuMDIHF+Q9DGzT2KtcTg8z4TvS5xjUeCIdV/6bUJJU1/y/hrLKf98EN1rmPhJVu03PHENlDIykq9IdY5jg=,iv:kmpfU5XCMUr+TvXegY/FAbrTyGRK5hR6WwSE7EkUE4g=,tag:Y6ofD9j2U23OqSzxHXWhZQ==,type:str]
     pgp: []
     unencrypted_suffix: _unencrypted
     version: 3.7.3

--- a/shared/erase-your-darlings/default.nix
+++ b/shared/erase-your-darlings/default.nix
@@ -63,9 +63,6 @@ in
     services.dockerRegistry.storagePath = "${toString cfg.persistDir}/var/lib/docker-registry";
     services.syncthing.dataDir = "${toString cfg.persistDir}/var/lib/syncthing";
 
-    # my services
-    nixfiles.foundryvtt.dataDir = "${toString cfg.persistDir}/srv/foundry";
-    nixfiles.minecraft.dataDir = "${toString cfg.persistDir}/srv/minecraft";
     nixfiles.oci-containers.volumeBaseDir = "${toString cfg.persistDir}/docker-volumes";
   };
 }

--- a/shared/foundryvtt/default.nix
+++ b/shared/foundryvtt/default.nix
@@ -8,6 +8,8 @@ let
   cfg = config.nixfiles.foundryvtt;
 in
 {
+  imports = [ ./erase-your-darlings.nix ];
+
   options.nixfiles.foundryvtt = {
     enable = mkOption { type = types.bool; default = false; };
     port = mkOption { type = types.int; default = 3000; };

--- a/shared/foundryvtt/erase-your-darlings.nix
+++ b/shared/foundryvtt/erase-your-darlings.nix
@@ -1,0 +1,12 @@
+{ config, lib, ... }:
+
+with lib;
+let
+  cfg = config.nixfiles.foundryvtt;
+  eyd = config.nixfiles.eraseYourDarlings;
+in
+{
+  config = mkIf (cfg.enable && eyd.enable) {
+    nixfiles.foundryvtt.dataDir = "${toString eyd.persistDir}/srv/foundry";
+  };
+}

--- a/shared/minecraft/default.nix
+++ b/shared/minecraft/default.nix
@@ -7,6 +7,8 @@ let
   serverPorts = mapAttrsToList (_: server: server.port) cfg.servers;
 in
 {
+  imports = [ ./erase-your-darlings.nix ];
+
   # yes I know there's a NixOS minecraft module but it uses the
   # Minecraft in nixpkgs whereas I want to run modded servers and
   # packaging one is a pain.

--- a/shared/minecraft/erase-your-darlings.nix
+++ b/shared/minecraft/erase-your-darlings.nix
@@ -1,0 +1,12 @@
+{ config, lib, ... }:
+
+with lib;
+let
+  cfg = config.nixfiles.minecraft;
+  eyd = config.nixfiles.eraseYourDarlings;
+in
+{
+  config = mkIf (cfg.enable && eyd.enable) {
+    nixfiles.minecraft.dataDir = "${toString eyd.persistDir}/srv/minecraft";
+  };
+}

--- a/shared/pleroma/default.nix
+++ b/shared/pleroma/default.nix
@@ -1,4 +1,4 @@
-{ config, lib, pkgs, ... }:
+{ config, lib, pkgs, pkgsUnstable, ... }:
 
 with lib;
 let
@@ -6,10 +6,10 @@ let
   backend = config.nixfiles.oci-containers.backend;
 in
 {
-  # TODO: consider switching to the standard pleroma module
+  imports = [ ./erase-your-darlings.nix ];
+
   options.nixfiles.pleroma = {
     enable = mkOption { type = types.bool; default = false; };
-    image = mkOption { type = types.str; };
     port = mkOption { type = types.int; default = 4000; };
     pgTag = mkOption { type = types.str; default = "13"; };
     domain = mkOption { type = types.str; };
@@ -17,36 +17,63 @@ in
     instanceName = mkOption { type = types.str; default = cfg.domain; };
     adminEmail = mkOption { type = types.str; default = "mike@barrucadu.co.uk"; };
     notifyEmail = mkOption { type = types.str; default = cfg.adminEmail; };
+    allowRegistration = mkOption { type = types.bool; default = false; };
     secretsFile = mkOption { type = types.str; };
-    registry = {
-      username = mkOption { type = types.nullOr types.str; default = null; };
-      passwordFile = mkOption { type = types.nullOr types.str; default = null; };
-      url = mkOption { type = types.nullOr types.str; default = null; };
-    };
   };
 
   config = mkIf cfg.enable {
-    nixfiles.oci-containers.containers.pleroma = {
-      image = cfg.image;
-      login = with cfg.registry; { inherit username passwordFile; registry = url; };
+    services.pleroma.enable = true;
+    services.pleroma.package = pkgsUnstable.pleroma;
+    services.pleroma.configs = [
+      ''
+        import Config
+
+        config :pleroma, Pleroma.Web.Endpoint,
+          url: [host: System.fetch_env!("DOMAIN"), scheme: "https", port: 443],
+          http: [ip: {127, 0, 0, 1}, port: System.fetch_env!("PORT") |> String.to_integer]
+
+        config :pleroma, :instance,
+          name: System.fetch_env!("INSTANCE_NAME"),
+          email: System.fetch_env!("ADMIN_EMAIL"),
+          notify_email: System.fetch_env!("NOTIFY_EMAIL"),
+          limit: 5000,
+          registrations_open: System.fetch_env!("ALLOW_REGISTRATION") |> String.to_atom,
+          healthcheck: true
+
+        config :pleroma, Pleroma.Repo,
+          adapter: Ecto.Adapters.Postgres,
+          username: "pleroma",
+          password: "pleroma",
+          database: "pleroma",
+          socket_dir: "/var/run/pleroma/db/",
+          pool_size: 10
+
+        config :web_push_encryption, :vapid_details, subject: "mailto:#{System.fetch_env!("NOTIFY_EMAIL")}"
+        config :pleroma, :database, rum_enabled: false
+        config :pleroma, :instance, static_dir: "/var/lib/pleroma/static"
+        config :pleroma, Pleroma.Uploaders.Local, uploads: "/var/lib/pleroma/uploads"
+
+        config :os_mon,
+          start_cpu_sup: false,
+          start_disksup: false,
+          start_memsup: false
+      ''
+    ];
+    services.pleroma.secretConfigFile = cfg.secretsFile;
+
+    systemd.services.pleroma = {
+      after = [ "docker-pleroma-db.service" ];
+      requires = [ "docker-pleroma-db.service" ];
       environment = {
-        "DOMAIN" = cfg.domain;
-        "INSTANCE_NAME" = cfg.instanceName;
-        "ADMIN_EMAIL" = cfg.adminEmail;
-        "NOTIFY_EMAIL" = cfg.notifyEmail;
-        "DB_USER" = "pleroma";
-        "DB_PASS" = "pleroma";
-        "DB_NAME" = "pleroma";
-        "DB_HOST" = "pleroma-db";
+        DOMAIN = cfg.domain;
+        PORT = toString cfg.port;
+        INSTANCE_NAME = cfg.instanceName;
+        ADMIN_EMAIL = cfg.adminEmail;
+        NOTIFY_EMAIL = cfg.notifyEmail;
+        ALLOW_REGISTRATION = if cfg.allowRegistration then "true" else "false";
       };
-      dependsOn = [ "pleroma-db" ];
-      network = "pleroma_network";
-      ports = [{ host = cfg.port; inner = 4000; }];
-      volumes = [
-        { name = "uploads"; inner = "/var/lib/pleroma/uploads"; }
-        { name = "emojis"; inner = "/var/lib/pleroma/static/emoji/custom"; }
-        { host = cfg.secretsFile; inner = "/var/lib/pleroma/secret.exs"; }
-      ] ++ (if cfg.faviconPath == null then [ ] else [{ host = pkgs.copyPathToStore cfg.faviconPath; inner = "/var/lib/pleroma/static/favicon.png"; }]);
+      serviceConfig.BindPaths =
+        "${toString (pkgs.copyPathToStore cfg.faviconPath)}:/var/lib/pleroma/static/favicon.png";
     };
 
     nixfiles.oci-containers.containers.pleroma-db = {
@@ -57,15 +84,32 @@ in
         "POSTGRES_PASSWORD" = "pleroma";
       };
       extraOptions = [ "--shm-size=1g" ];
-      network = "pleroma_network";
-      volumes = [{ name = "pgdata"; inner = "/var/lib/postgresql/data"; }];
+      volumes = [
+        { name = "pgdata"; inner = "/var/lib/postgresql/data"; }
+        { host = "/var/run/pleroma/db"; inner = "/var/run/postgresql"; }
+      ];
       volumeSubDir = "pleroma";
     };
 
+    # TODO: figure out how to get `sudo` in the unit's path (adding the package
+    # doesn't help - need the wrapper)
     nixfiles.backups.scripts.pleroma = ''
-      ${backend} cp "pleroma:/var/lib/pleroma/uploads" uploads
-      ${backend} cp "pleroma:/var/lib/pleroma/static/emoji/custom" emojis
-      ${backend} exec -i pleroma-db pg_dump -U pleroma --no-owner pleroma | gzip -9 > dump.sql.gz
+      /run/wrappers/bin/sudo cp -a ${config.users.users.pleroma.home}/uploads uploads
+      /run/wrappers/bin/sudo cp -a ${config.users.users.pleroma.home}/static/emoji/custom emoji
+      /run/wrappers/bin/sudo chown -R ${config.nixfiles.backups.user}.${config.nixfiles.backups.group} uploads
+      /run/wrappers/bin/sudo chown -R ${config.nixfiles.backups.user}.${config.nixfiles.backups.group} emoji
+      ${backend} exec -i pleroma-db pg_dump -U pleroma --no-owner -Fc pleroma > postgres.dump
     '';
+    security.sudo.extraRules = [
+      {
+        users = [ config.nixfiles.backups.user ];
+        commands = [
+          { command = "${pkgs.coreutils}/bin/cp -a ${config.users.users.pleroma.home}/uploads uploads"; options = [ "NOPASSWD" ]; }
+          { command = "${pkgs.coreutils}/bin/cp -a ${config.users.users.pleroma.home}/static/emoji/custom emoji"; options = [ "NOPASSWD" ]; }
+          { command = "${pkgs.coreutils}/bin/chown -R ${config.nixfiles.backups.user}.${config.nixfiles.backups.group} uploads"; options = [ "NOPASSWD" ]; }
+          { command = "${pkgs.coreutils}/bin/chown -R ${config.nixfiles.backups.user}.${config.nixfiles.backups.group} emoji"; options = [ "NOPASSWD" ]; }
+        ];
+      }
+    ];
   };
 }

--- a/shared/pleroma/erase-your-darlings.nix
+++ b/shared/pleroma/erase-your-darlings.nix
@@ -1,0 +1,16 @@
+{ config, lib, ... }:
+
+with lib;
+let
+  cfg = config.nixfiles.pleroma;
+  eyd = config.nixfiles.eraseYourDarlings;
+
+  # systemd unit assumes files are accessible under "/var/lib/pleroma"
+  pleromaHome = "${toString eyd.persistDir}/var/lib/pleroma";
+in
+{
+  config = mkIf (cfg.enable && eyd.enable) {
+    users.users.pleroma.home = mkForce pleromaHome;
+    systemd.services.pleroma.serviceConfig.BindPaths = "${pleromaHome}:/var/lib/pleroma";
+  };
+}


### PR DESCRIPTION
The standard Pleroma module is good enough, and means I don't need to build my own containers from the develop branch - which isn't a supported approach anyway and frequently breaks.

I need to use the Pleroma from nixpkgs-unstable because my current image is based on 2.5, but nixpkgs only has 2.4, which isn't compatible due to database changes.

The database is still dockerised, so it's not subject to the whims of `system.stateVersion`.

I've also changed the backup script to use the custom pgdump format, because that can be restored in parallel.  A test run only took 90 minutes (plus another 9 minutes to run a `VACUUM ANALYZE`), which is much better than the 3 *days* it took when I last had to restore a SQL dump.