### PR TITLE
[carcosa] Do not open port 222

### DIFF
--- a/hosts/carcosa/configuration.nix
+++ b/hosts/carcosa/configuration.nix
@@ -37,7 +37,7 @@ in
   boot.loader.grub.device = "/dev/sda";
 
   # Networking
-  networking.firewall.allowedTCPPorts = [ 80 222 443 ];
+  networking.firewall.allowedTCPPorts = [ 80 443 ];
 
   networking.interfaces.enp1s0 = {
     ipv6.addresses = [{ address = "2a01:4f8:c0c:bfc1::"; prefixLength = 64; }];


### PR DESCRIPTION
This was the gitea SSH port, but I stopped using gitea in 2022.