### PR TITLE
Set `networking.hostName` in flake.nix

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -23,8 +23,11 @@
             inherit system;
             specialArgs = { inherit flakeInputs pkgsUnstable; };
             modules = [
+              {
+                networking.hostName = name;
+                nixpkgs.overlays = [ (_: _: { nixfiles = self.packages.${system}; }) ];
+              }
               ./shared
-              { nixpkgs.overlays = [ (_: _: { nixfiles = self.packages.${system}; }) ]; }
               # nix-linter doesn't support the ./hosts/${name}/foo.nix syntax yet
               (./hosts + "/${name}" + /configuration.nix)
               (./hosts + "/${name}" + /hardware.nix)

--- a/hosts/azathoth/configuration.nix
+++ b/hosts/azathoth/configuration.nix
@@ -8,8 +8,6 @@ let
     };
 in
 {
-  networking.hostName = "azathoth";
-
   # Bootloader
   boot.loader.systemd-boot.enable = true;
   boot.loader.efi.canTouchEfiVariables = true;

--- a/hosts/carcosa/configuration.nix
+++ b/hosts/carcosa/configuration.nix
@@ -25,7 +25,6 @@ in
   ## General
   ###############################################################################
 
-  networking.hostName = "carcosa";
   networking.hostId = "f62895cc";
   boot.supportedFilesystems = [ "zfs" ];
 

--- a/hosts/lainonlife/configuration.nix
+++ b/hosts/lainonlife/configuration.nix
@@ -56,8 +56,6 @@ let
   };
 in
 {
-  networking.hostName = "lainonlife";
-
   sops.defaultSopsFile = ./secrets.yaml;
 
   # Bootloader

--- a/hosts/nyarlathotep/configuration.nix
+++ b/hosts/nyarlathotep/configuration.nix
@@ -22,7 +22,6 @@ in
   ## General
   ###############################################################################
 
-  networking.hostName = "nyarlathotep";
   networking.hostId = "4a592971"; # ZFS needs one of these
   boot.supportedFilesystems = [ "zfs" ];
 


### PR DESCRIPTION
This needs to be kept in sync between both places, so just define it in one.