### PR TITLE
Set `sops.defaultSopsFile` in flake.nix

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -19,7 +19,7 @@
 
       nixosConfigurations =
         let
-          mkNixosConfiguration = name: extraModules: nixpkgs.lib.nixosSystem {
+          mkNixosConfiguration = name: secrets: extraModules: nixpkgs.lib.nixosSystem {
             inherit system;
             specialArgs = { inherit flakeInputs pkgsUnstable; };
             modules = [
@@ -31,14 +31,15 @@
               # nix-linter doesn't support the ./hosts/${name}/foo.nix syntax yet
               (./hosts + "/${name}" + /configuration.nix)
               (./hosts + "/${name}" + /hardware.nix)
-            ] ++ extraModules;
+            ] ++ extraModules ++
+            (if secrets then [ sops-nix.nixosModules.sops { sops.defaultSopsFile = ./hosts + "/${name}" + /secrets.yaml; } ] else [ ]);
           };
         in
         {
-          azathoth = mkNixosConfiguration "azathoth" [ "${nixpkgs}/nixos/modules/installer/scan/not-detected.nix" ];
-          carcosa = mkNixosConfiguration "carcosa" [ "${nixpkgs}/nixos/modules/profiles/qemu-guest.nix" sops-nix.nixosModules.sops ];
-          lainonlife = mkNixosConfiguration "lainonlife" [ "${nixpkgs}/nixos/modules/installer/scan/not-detected.nix" sops-nix.nixosModules.sops ];
-          nyarlathotep = mkNixosConfiguration "nyarlathotep" [ "${nixpkgs}/nixos/modules/installer/scan/not-detected.nix" sops-nix.nixosModules.sops ];
+          azathoth = mkNixosConfiguration "azathoth" false [ "${nixpkgs}/nixos/modules/installer/scan/not-detected.nix" ];
+          carcosa = mkNixosConfiguration "carcosa" true [ "${nixpkgs}/nixos/modules/profiles/qemu-guest.nix" ];
+          lainonlife = mkNixosConfiguration "lainonlife" true [ "${nixpkgs}/nixos/modules/installer/scan/not-detected.nix" ];
+          nyarlathotep = mkNixosConfiguration "nyarlathotep" true [ "${nixpkgs}/nixos/modules/installer/scan/not-detected.nix" ];
         };
 
       packages.${system} =

--- a/hosts/carcosa/configuration.nix
+++ b/hosts/carcosa/configuration.nix
@@ -28,8 +28,6 @@ in
   networking.hostId = "f62895cc";
   boot.supportedFilesystems = [ "zfs" ];
 
-  sops.defaultSopsFile = ./secrets.yaml;
-
   # Bootloader
   boot.loader.grub.enable = true;
   boot.loader.grub.version = 2;

--- a/hosts/lainonlife/configuration.nix
+++ b/hosts/lainonlife/configuration.nix
@@ -56,8 +56,6 @@ let
   };
 in
 {
-  sops.defaultSopsFile = ./secrets.yaml;
-
   # Bootloader
   boot.loader.grub.enable = true;
   boot.loader.grub.version = 2;

--- a/hosts/nyarlathotep/configuration.nix
+++ b/hosts/nyarlathotep/configuration.nix
@@ -25,8 +25,6 @@ in
   networking.hostId = "4a592971"; # ZFS needs one of these
   boot.supportedFilesystems = [ "zfs" ];
 
-  sops.defaultSopsFile = ./secrets.yaml;
-
   # Bootloader
   boot.loader.systemd-boot.enable = true;
 


### PR DESCRIPTION
Previously, enabling secrets on a host required updating two files: enabling the module in flake.nix and setting a default file in the host configuration.  This commit puts all that in one place.