### PR TITLE
Run bookmarks outside of docker

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -43,6 +43,7 @@
 
       packages.${system} =
         {
+          bookmarks = pkgs.callPackage ./packages/bookmarks { };
           prometheus-awair-exporter = pkgs.callPackage ./packages/prometheus-awair-exporter { };
           resolved = pkgs.callPackage ./packages/resolved { };
         };

--- a/hosts/carcosa/configuration.nix
+++ b/hosts/carcosa/configuration.nix
@@ -4,7 +4,6 @@ with lib;
 let
   dockerRegistryPort = 3000;
   bookdbPort = 3001;
-  bookmarksPort = 3002;
   concoursePort = 3003;
   umamiPort = 3006;
   concourseMetricsPort = 3009;
@@ -351,11 +350,8 @@ in
 
   # bookmarks
   nixfiles.bookmarks.enable = true;
-  nixfiles.bookmarks.image = "registry.barrucadu.dev/bookmarks:latest";
-  nixfiles.bookmarks.registry = registryBarrucaduDev;
   nixfiles.bookmarks.baseURI = "https://bookmarks.barrucadu.co.uk";
   nixfiles.bookmarks.readOnly = true;
-  nixfiles.bookmarks.port = bookmarksPort;
 
   # concourse
   nixfiles.concourse.enable = true;
@@ -423,7 +419,6 @@ in
       users = [ "concourse-deploy-robot" ];
       commands = [
         { command = "${pkgs.systemd}/bin/systemctl restart docker-bookdb"; options = [ "NOPASSWD" ]; }
-        { command = "${pkgs.systemd}/bin/systemctl restart docker-bookmarks"; options = [ "NOPASSWD" ]; }
       ];
     }
   ];

--- a/hosts/nyarlathotep/configuration.nix
+++ b/hosts/nyarlathotep/configuration.nix
@@ -8,7 +8,6 @@ let
   bookdbPort = 3000;
   floodPort = 3001;
   finderPort = 3002;
-  bookmarksPort = 3003;
   grafanaPort = 3004;
   promscalePort = 9201;
   prometheusAwairExporterPort = 9517;
@@ -275,16 +274,14 @@ in
   ###############################################################################
 
   nixfiles.bookmarks.enable = true;
-  nixfiles.bookmarks.image = "localhost:5000/bookmarks:latest";
   nixfiles.bookmarks.baseURI = "http://bookmarks.nyarlathotep.lan";
-  nixfiles.bookmarks.port = bookmarksPort;
   nixfiles.bookmarks.environmentFile = config.sops.secrets."nixfiles/bookmarks/env".path;
   sops.secrets."nixfiles/bookmarks/env" = { };
 
   systemd.services.bookmarks-sync = {
     description = "Upload bookmarks data to carcosa";
     startAt = "hourly";
-    path = with pkgs; [ docker openssh ];
+    path = with pkgs; [ openssh systemd ];
     serviceConfig = {
       ExecStart = pkgs.writeShellScript "bookmarks-sync.sh" (fileContents ./jobs/bookmarks-sync.sh);
       User = "barrucadu";

--- a/hosts/nyarlathotep/jobs/bookmarks-sync.sh
+++ b/hosts/nyarlathotep/jobs/bookmarks-sync.sh
@@ -4,11 +4,13 @@ set -euo pipefail
 
 local_sync_dir="$(mktemp -d)"
 remote_sync_dir="/tmp/bookmarks-sync"
+es_host="$(systemctl cat bookmarks | grep ES_HOST | cut -d'=' -f3 | sed 's/"//')"
+python="$(systemctl cat bookmarks | grep ExecStart | sed 's/^ExecStart=//' | sed 's/gunicorn.*/python/')"
 
 # shellcheck disable=SC2064
 trap "rm -rf $local_sync_dir" EXIT
 
-docker exec -i bookmarks env ES_HOST=http://bookmarks-db:9200 python -m bookmarks.index.dump > "${local_sync_dir}/dump.json"
+env "ES_HOST=$es_host" "$python" -m bookmarks.index.dump > "${local_sync_dir}/dump.json"
 
 scp -r "$local_sync_dir" "carcosa.barrucadu.co.uk:${remote_sync_dir}"
 
@@ -16,8 +18,11 @@ scp -r "$local_sync_dir" "carcosa.barrucadu.co.uk:${remote_sync_dir}"
 ssh carcosa.barrucadu.co.uk <<EOF
 set -euo pipefail
 
+es_host="\$(systemctl cat bookmarks | grep ES_HOST | cut -d'=' -f3 | sed 's/"//')"
+python="\$(systemctl cat bookmarks | grep ExecStart | sed 's/^ExecStart=//' | sed 's/gunicorn.*/python/')"
+
 trap "rm -rf $remote_sync_dir" EXIT
 
 cd "$remote_sync_dir"
-docker exec -i bookmarks env DELETE_EXISTING_INDEX=1 ES_HOST=http://bookmarks-db:9200 python -m bookmarks.index.create - < dump.json
+env DELETE_EXISTING_INDEX=1 ES_HOST=\$es_host \$python -m bookmarks.index.create - < dump.json
 EOF

--- a/packages/bookmarks/default.nix
+++ b/packages/bookmarks/default.nix
@@ -1,0 +1,17 @@
+{ poetry2nix, fetchFromGitHub, ... }:
+
+let
+  app = poetry2nix.mkPoetryApplication {
+    projectDir = fetchFromGitHub {
+      owner = "barrucadu";
+      repo = "bookmarks";
+      rev = "c631c387c10cb8ff090ea90515734c3954a10079";
+      sha256 = "sha256-5QxYJ5Tofhfxu9ixZNEOR4BT+Wwx/HdBKvpSZv6WB0c=";
+    };
+
+    overrides = poetry2nix.overrides.withDefaults (_: super: {
+      elastic-transport = super.elastic-transport.overridePythonAttrs (old: { buildInputs = (old.buildInputs or [ ]) ++ [ super.setuptools ]; });
+    });
+  };
+in
+app.dependencyEnv


### PR DESCRIPTION
Natively packaging this application isn't very hard.  It does make the sync script a little more complex, as it's got to work out the appropriate path to the python environment, but that's not too tricky.

This also makes deploying updates to nyarlathotep a little easier: I don't need to build a docker image, push it to a local repo, and restart the service any more.  I just bump the version in the package, same as resolved and prometheus-awair-exporter.

Needing to expose the Elasticsearch instance to localhost is a bit unfortunate, however.  Maybe I'll be able to do some systemd network namespacing magic and lock that down at some point.

I also changed the bookdb port to be a random one in the high end of the user ports range which is unlikely to clash with anything else.