### PR TITLE
Run bookdb outside of docker

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -43,6 +43,7 @@
 
       packages.${system} =
         {
+          bookdb = pkgs.callPackage ./packages/bookdb { };
           bookmarks = pkgs.callPackage ./packages/bookmarks { };
           prometheus-awair-exporter = pkgs.callPackage ./packages/prometheus-awair-exporter { };
           resolved = pkgs.callPackage ./packages/resolved { };

--- a/hosts/carcosa/secrets.yaml
+++ b/hosts/carcosa/secrets.yaml
@@ -18,8 +18,6 @@ services:
         fragments:
             misc_site: ENC[AES256_GCM,data:y8VPYPzlrdFdODmbtZ8o7aMKm+hZLpc0kkuXatth29RfsN1XO1sfgIj4bPmDpUUf5yQQLsKK4F/cULnhMU0TOhOMKHzTduh59b6pxmJgbufETX1Hghnq+zLx,iv:QgbGVm3Vj1PtU6/W31xDUoxtPSgS8ot8IBqOxfeaJQk=,tag:kLfPVxrLdxtXwfIHC2y8Rg==,type:str]
             registry: ENC[AES256_GCM,data:TMXUTbMzpP8QHW4aAyW2auGQYFhV3cHjfne0AnQ+CFI41A/3SuelQumQR17HOr9Z/Hs5LQQ9QssqQlhwOEMCIuTu2x81AUuEdineJc1T/xq1nhCrWA8olVI=,iv:dov05Z5jkB44lEQI0DPieDjT9thfHJE1vTiIYZbA79M=,tag:fIBo46vac8Ciu/dO1Bl18A==,type:str]
-    docker_registry:
-        login: ENC[AES256_GCM,data:+KLBRqmNFD27af4Ri6QYo9jF16zu2Evm+DO4uUqdGrWecLOw,iv:tAgFgH2/kIcufjNjcyeHWYsrR5eFys/08d+zyk2rTlI=,tag:JzRmrCGouvXVzS7MUkwvYA==,type:str]
     grafana:
         admin_password: ENC[AES256_GCM,data:nGzl+HjDKz/ushife6YLCXtzTpIlHrbqPFWxsV3QxhG5FwXj5+vPNo8Pyg==,iv:j+ZS5PXFqV7t/mGK5lRQv0pG7+sh2BHy3N7MQ0YgWTY=,tag:F9r2iiMxG4xnFIz0vnP88w==,type:str]
         secret_key: ENC[AES256_GCM,data:KeWJ9AVXCYjFgaFWbV7rqGRKOLT+lqzLP/p3Dajnemk=,iv:rfcm8PordRN0bCQmIQ7flZ/ShaCG1X30wUtHDjLD79Q=,tag:C+Ze2RmQ9yfR5/6K6oMqlA==,type:str]
@@ -47,8 +45,8 @@ sops:
             dTQwclBRU3JmQ2hBOFVlaVIxZHN4cVEKvVR1bSH4yo2Td8YGNI2hmflT0M3hcYu8
             qyYoWd5MFP9VBYKxrF8W2naQSY6Ax4IiVuNbKDDLFooTC93V+oxNDA==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2023-03-12T12:27:04Z"
-    mac: ENC[AES256_GCM,data:RxAWV1n0PqPIK4+7+Y05HXV11THb3hTP/xgh04VHNyDK1JUKSaag2cQFbTz/pfLHoL1XUeKzFe/dgnkNohEH91ZrsqNTu3uqMdFvPlDsR2pQvSRFb+bSC62nSFRkKOCoEXOi7zc8nE2k03RVgdHi6B60A/uA0NrU2diLHvxLOfg=,iv:pJbh6G7vxOKi5ne9y/6wiktqw8rh6/SqYICptvdBrDk=,tag:ZdtCR2cfUp2piyIIv2tSgA==,type:str]
+    lastmodified: "2023-04-01T13:59:46Z"
+    mac: ENC[AES256_GCM,data:TmeJV5P+bAQ3IfnIWrEGlCQ1VuBv6dDTxT5l6v++cvTSAY+ed2kE0nfc+D159EvX2KkcUSPcApZyQPCk4EuREQwdd6ugb1SAowZSe3I62uZRegZhdAEVfOip1e9zFXyPSNFLoCo/q7xaBI8anLxpEjIzLhyn3WyR/ecs6BVS67w=,iv:2jNyjkXTDcc5qHXFjHODKZNOmoj8K3BJbhUjZwjOKVg=,tag:t+66U+bgYFY0H+xFXGbaJg==,type:str]
     pgp: []
     unencrypted_suffix: _unencrypted
     version: 3.7.3

--- a/packages/bookdb/default.nix
+++ b/packages/bookdb/default.nix
@@ -1,0 +1,22 @@
+{ poetry2nix, fetchFromGitHub, ... }:
+
+let
+  app = poetry2nix.mkPoetryApplication {
+    projectDir = fetchFromGitHub {
+      owner = "barrucadu";
+      repo = "bookdb";
+      rev = "cb17cdc6ce63a38d8ebfec8e82c57e51a86a63a0";
+      sha256 = "sha256-W5bHAgzC+6u5sdVgta/NhCLz7NSHHOnKcQXPxsU3dB8=";
+    };
+
+    overrides = poetry2nix.overrides.withDefaults (_: super: {
+      elastic-transport = super.elastic-transport.overridePythonAttrs (old: { buildInputs = (old.buildInputs or [ ]) ++ [ super.setuptools ]; });
+    });
+
+    postFixup = ''
+      cd config
+      find . -type f -exec install -Dm 755 "{}" "$out/etc/bookdb/config/{}" \;
+    '';
+  };
+in
+app.dependencyEnv

--- a/shared/bookdb/erase-your-darlings.nix
+++ b/shared/bookdb/erase-your-darlings.nix
@@ -1,0 +1,12 @@
+{ config, lib, ... }:
+
+with lib;
+let
+  cfg = config.nixfiles.bookdb;
+  eyd = config.nixfiles.eraseYourDarlings;
+in
+{
+  config = mkIf (cfg.enable && eyd.enable) {
+    nixfiles.bookdb.dataDir = "${toString eyd.persistDir}/srv/bookdb";
+  };
+}


### PR DESCRIPTION
Natively packaging this application isn't very hard.  It does make the sync and backup scripts a little more complex, as they now need to handle retrieving files owned by the bookdb user, but that's not too tricky.

This also makes deploying updates to nyarlathotep a little easier: I don't need to build a docker image, push it to a local repo, and restart the service any more.  I just bump the version in the package, same as bookmarks, resolved, and prometheus-awair-exporter.

Needing to expose the Elasticsearch instance to localhost is a bit unfortunate, however.  Maybe I'll be able to do some systemd network namespacing magic and lock that down at some point.

I also changed the bookdb port to be a random one in the high end of the user ports range which is unlikely to clash with anything else.

This also lets me remove the remote-sync users from the `docker` group, and remove the concourse-deploy-robot from carcosa.  The docker registries on carcosa and nyarlathotep are still needed for now, though.