### PR TITLE
[carcosa] Bring back concourse-deploy-robot user

### DIFF
--- a/hosts/carcosa/configuration.nix
+++ b/hosts/carcosa/configuration.nix
@@ -449,6 +449,17 @@ in
 
   services.prometheus.webExternalUrl = "https://prometheus.carcosa.barrucadu.co.uk";
 
+  # Concourse access
+  users.extraUsers.concourse-deploy-robot = {
+    home = "/var/lib/concourse-deploy-robot";
+    createHome = true;
+    isSystemUser = true;
+    openssh.authorizedKeys.keys =
+      [ "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIFilTWek5xNpl82V48oQ99briJhn9BqwCACeRq1dQnZn concourse-worker@cd.barrucadu.dev" ];
+    shell = pkgs.bashInteractive;
+    group = "nogroup";
+  };
+
   # Extra packages
   users.extraUsers.barrucadu.packages = with pkgs; [
     irssi


### PR DESCRIPTION
Incorrectly removed in fd2f334.

This is of course still needed to deploy the static sites.