### PR TITLE
[nyarlathotep] Offset sync from backup schedule

### DIFF
--- a/hosts/nyarlathotep/configuration.nix
+++ b/hosts/nyarlathotep/configuration.nix
@@ -515,7 +515,7 @@ in
 
   systemd.services.bookdb-sync = {
     description = "Upload bookdb data to carcosa";
-    startAt = "hourly";
+    startAt = "*:15";
     path = with pkgs; [ openssh rsync ];
     serviceConfig = {
       ExecStart = pkgs.writeShellScript "bookdb-sync" ''
@@ -551,7 +551,7 @@ in
 
   systemd.services.bookmarks-sync = {
     description = "Upload bookmarks data to carcosa";
-    startAt = "hourly";
+    startAt = "*:15";
     path = with pkgs; [ openssh ];
     serviceConfig = {
       ExecStart = pkgs.writeShellScript "bookmarks-sync" ''


### PR DESCRIPTION
These occasionally collide right now.  Usually that makes the backup fail (since the collision tends to be with the bookdb cover files changing while the backup `tar` is running, which throws an error), but if it happened during the elasticsearch index sync I could end up backing up incomplete data.

Another option would be adding some sort of lockfile which prevents both running at the same time, but this is simpler.