### PR TITLE
Add `nixpkgs-unstable` to system flake registry

### DIFF
--- a/shared/default.nix
+++ b/shared/default.nix
@@ -56,6 +56,7 @@ in
     # system
     nix.extraOptions = "experimental-features = nix-command flakes";
     nix.registry.nixpkgs.flake = flakeInputs.nixpkgs;
+    nix.registry.nixpkgs-unstable.flake = flakeInputs.nixpkgs-unstable;
 
     # Clear out /tmp after a fortnight and give all normal users a ~/tmp
     # cleaned out weekly.


### PR DESCRIPTION
This is handy for opening a nix shell.