### PR TITLE
Always enable deletion and garbage collection for docker registries

### DIFF
--- a/hosts/carcosa/configuration.nix
+++ b/hosts/carcosa/configuration.nix
@@ -338,8 +338,6 @@ in
 
   # Docker registry
   services.dockerRegistry.enable = true;
-  services.dockerRegistry.enableDelete = true;
-  services.dockerRegistry.enableGarbageCollect = true;
   services.dockerRegistry.port = dockerRegistryPort;
 
   # bookdb

--- a/hosts/nyarlathotep/configuration.nix
+++ b/hosts/nyarlathotep/configuration.nix
@@ -409,7 +409,6 @@ in
   ###############################################################################
 
   services.dockerRegistry.enable = true;
-  services.dockerRegistry.enableGarbageCollect = true;
   virtualisation.docker.extraOptions = "--insecure-registry=localhost:5000";
 
 

--- a/shared/default.nix
+++ b/shared/default.nix
@@ -182,6 +182,10 @@ in
     virtualisation.docker.enable = true;
     virtualisation.docker.autoPrune.enable = true;
 
+    # If running a docker registry, also enable deletion and garbage collection.
+    services.dockerRegistry.enableDelete = config.services.dockerRegistry.enable;
+    services.dockerRegistry.enableGarbageCollect = config.services.dockerRegistry.enable;
+
     #############################################################################
     ## Dashboards & Alerting
     #############################################################################


### PR DESCRIPTION
There's no need to enable this per-host, since I always want these.