### PR TITLE
Use systemd OneShot units for docker networks

### DIFF
--- a/hosts/nyarlathotep/configuration.nix
+++ b/hosts/nyarlathotep/configuration.nix
@@ -490,7 +490,7 @@ in
     image = "timescale/promscale:latest";
     cmd = [ "-db.host=promscale-db" "-db.name=postgres" "-db.password=promscale" "-db.ssl-mode=allow" "-web.enable-admin-api=true" "-metrics.promql.lookback-delta=168h" ];
     dependsOn = [ "promscale-db" ];
-    network = "promscale_network";
+    network = "promscale";
     ports = [{ host = promscalePort; inner = 9201; }];
   };
   nixfiles.oci-containers.containers.promscale-db = {
@@ -498,7 +498,7 @@ in
     environment = {
       POSTGRES_PASSWORD = "promscale";
     };
-    network = "promscale_network";
+    network = "promscale";
     volumes = [{ name = "pgdata"; inner = "/var/lib/postgresql/data"; }];
     volumeSubDir = "promscale";
   };

--- a/shared/concourse/default.nix
+++ b/shared/concourse/default.nix
@@ -39,7 +39,7 @@ in
       };
       environmentFiles = [ cfg.environmentFile ];
       dependsOn = [ "concourse-db" ];
-      network = "concourse_network";
+      network = "concourse";
       ports = [
         { host = cfg.port; inner = 8080; }
         { host = cfg.metricsPort; inner = 8088; }
@@ -59,7 +59,7 @@ in
       };
       extraOptions = [ "--privileged" ];
       dependsOn = [ "concourse-web" ];
-      network = "concourse_network";
+      network = "concourse";
       volumes =
         [{ name = "keys/worker"; inner = "/concourse-keys"; }] ++
         (if cfg.workerScratchDir == null then [ ] else [{ host = cfg.workerScratchDir; inner = "/workdir"; }]);
@@ -73,7 +73,7 @@ in
         "POSTGRES_USER" = "concourse";
         "POSTGRES_PASSWORD" = "concourse";
       };
-      network = "concourse_network";
+      network = "concourse";
       volumes = [{ name = "pgdata"; inner = "/var/lib/postgresql/data"; }];
       volumeSubDir = "concourse";
     };

--- a/shared/finder/default.nix
+++ b/shared/finder/default.nix
@@ -21,7 +21,7 @@ in
         "ES_HOST" = "http://finder-db:9200";
       };
       dependsOn = [ "finder-db" ];
-      network = "finder_network";
+      network = "finder";
       ports = [{ host = cfg.port; inner = 8888; }];
       volumes = [{ host = cfg.mangaDir; inner = "/data"; }];
     };
@@ -34,7 +34,7 @@ in
         "xpack.security.enabled" = "false";
         "ES_JAVA_OPTS" = "-Xms512M -Xmx512M";
       };
-      network = "finder_network";
+      network = "finder";
       volumes = [{ name = "esdata"; inner = "/usr/share/elasticsearch/data"; }];
       volumeSubDir = "finder";
     };

--- a/shared/umami/default.nix
+++ b/shared/umami/default.nix
@@ -22,7 +22,7 @@ in
       };
       environmentFiles = [ cfg.environmentFile ];
       dependsOn = [ "umami-db" ];
-      network = "umami_network";
+      network = "umami";
       ports = [{ host = cfg.port; inner = 3000; }];
     };
 
@@ -33,7 +33,7 @@ in
         "POSTGRES_USER" = "umami";
         "POSTGRES_PASSWORD" = "umami";
       };
-      network = "umami_network";
+      network = "umami";
       volumes = [{ name = "pgdata"; inner = "/var/lib/postgresql/data"; }];
       volumeSubDir = "umami";
     };


### PR DESCRIPTION
This pulls the network management logic out of the preStart, allowing containers to depend on the network rather than every container trying to create the network and gracefully handling the case where it already exsts.  Also means networks can be cleaned up when containers stop.