### PR TITLE
Make pods a first-class citizen for OCI containers

### DIFF
--- a/hosts/nyarlathotep/configuration.nix
+++ b/hosts/nyarlathotep/configuration.nix
@@ -486,21 +486,22 @@ in
     };
   };
 
-  nixfiles.oci-containers.containers.promscale = {
-    image = "timescale/promscale:latest";
-    cmd = [ "-db.host=promscale-db" "-db.name=postgres" "-db.password=promscale" "-db.ssl-mode=allow" "-web.enable-admin-api=true" "-metrics.promql.lookback-delta=168h" ];
-    dependsOn = [ "promscale-db" ];
-    network = "promscale";
-    ports = [{ host = promscalePort; inner = 9201; }];
-  };
-  nixfiles.oci-containers.containers.promscale-db = {
-    image = "timescaledev/promscale-extension:latest-ts2-pg14";
-    environment = {
-      POSTGRES_PASSWORD = "promscale";
+  nixfiles.oci-containers.pods.promscale = {
+    containers = {
+      web = {
+        image = "timescale/promscale:latest";
+        cmd = [ "-db.host=promscale-db" "-db.name=postgres" "-db.password=promscale" "-db.ssl-mode=allow" "-web.enable-admin-api=true" "-metrics.promql.lookback-delta=168h" ];
+        dependsOn = [ "promscale-db" ];
+        ports = [{ host = promscalePort; inner = 9201; }];
+      };
+      db = {
+        image = "timescaledev/promscale-extension:latest-ts2-pg14";
+        environment = {
+          POSTGRES_PASSWORD = "promscale";
+        };
+        volumes = [{ name = "pgdata"; inner = "/var/lib/postgresql/data"; }];
+      };
     };
-    network = "promscale";
-    volumes = [{ name = "pgdata"; inner = "/var/lib/postgresql/data"; }];
-    volumeSubDir = "promscale";
   };
 
 

--- a/shared/finder/default.nix
+++ b/shared/finder/default.nix
@@ -14,29 +14,30 @@ in
   };
 
   config = mkIf cfg.enable {
-    nixfiles.oci-containers.containers.finder = {
-      image = cfg.image;
-      environment = {
-        "DATA_DIR" = "/data";
-        "ES_HOST" = "http://finder-db:9200";
-      };
-      dependsOn = [ "finder-db" ];
-      network = "finder";
-      ports = [{ host = cfg.port; inner = 8888; }];
-      volumes = [{ host = cfg.mangaDir; inner = "/data"; }];
-    };
+    nixfiles.oci-containers.pods.finder = {
+      containers = {
+        web = {
+          image = cfg.image;
+          environment = {
+            "DATA_DIR" = "/data";
+            "ES_HOST" = "http://finder-db:9200";
+          };
+          dependsOn = [ "finder-db" ];
+          ports = [{ host = cfg.port; inner = 8888; }];
+          volumes = [{ host = cfg.mangaDir; inner = "/data"; }];
+        };
 
-    nixfiles.oci-containers.containers.finder-db = {
-      image = "elasticsearch:${cfg.esTag}";
-      environment = {
-        "http.host" = "0.0.0.0";
-        "discovery.type" = "single-node";
-        "xpack.security.enabled" = "false";
-        "ES_JAVA_OPTS" = "-Xms512M -Xmx512M";
+        db = {
+          image = "elasticsearch:${cfg.esTag}";
+          environment = {
+            "http.host" = "0.0.0.0";
+            "discovery.type" = "single-node";
+            "xpack.security.enabled" = "false";
+            "ES_JAVA_OPTS" = "-Xms512M -Xmx512M";
+          };
+          volumes = [{ name = "esdata"; inner = "/usr/share/elasticsearch/data"; }];
+        };
       };
-      network = "finder";
-      volumes = [{ name = "esdata"; inner = "/usr/share/elasticsearch/data"; }];
-      volumeSubDir = "finder";
     };
   };
 }

--- a/shared/oci-containers/default.nix
+++ b/shared/oci-containers/default.nix
@@ -2,6 +2,13 @@
 
 with lib;
 let
+  mkPortDef = { host, inner }: "127.0.0.1:${toString host}:${toString inner}";
+
+  mkVolumeDef = container: { name, host, inner }:
+    if host != null
+    then "${host}:${inner}"
+    else "${cfg.volumeBaseDir}/${container.volumeSubDir}/${name}:${inner}";
+
   shouldPreStart = _name: container: container.pullOnStart;
   mkPreStart = name: container: nameValuePair "${cfg.backend}-${name}" {
     preStart = if container.pullOnStart then "${cfg.backend} pull ${container.image}" else "";
@@ -21,65 +28,110 @@ let
       };
     };
 
-  mkPortDef = { host, inner }: "127.0.0.1:${toString host}:${toString inner}";
+  mkPodService = name: pod:
+    let
+      package = if cfg.backend == "podman" then pkgs.podman else throw "mkPodService only supports podman";
+      ports = concatMap (container: container.ports) pod.containers;
+    in
+    nameValuePair "${cfg.backend}-pod-${name}" {
+      description = "Manage the ${name} pod for ${cfg.backend}";
+      preStart = "${package}/bin/${cfg.backend} pod rm --force --ignore ${name} || true";
+      serviceConfig = {
+        Type = "oneshot";
+        ExecStart = "${package}/bin/${cfg.backend} pod create ${concatMapStringsSep " " (pd: "-p ${mkPortDef pd}") ports} ${name}";
+        ExecStop = "${package}/bin/${cfg.backend} pod rm ${name}";
+        RemainAfterExit = "yes";
+      };
+    };
 
-  mkVolumeDef = container: { name, host, inner }:
-    if host != null
-    then "${host}:${inner}"
-    else "${cfg.volumeBaseDir}/${container.volumeSubDir}/${name}:${inner}";
-
-  mkContainer = _name: container: with container; {
-    inherit autoStart cmd environment environmentFiles image login;
-    dependsOn =
-      container.dependsOn ++
-      (if container.network != null then [ "net-${container.network}" ] else [ ]);
-    extraOptions =
-      container.extraOptions ++
-      (if container.network != null then [ "--network=${container.network}" ] else [ ]);
-    ports = map mkPortDef ports;
-    volumes = map (mkVolumeDef container) volumes;
-  };
+  mkContainer = _name: container: with container;
+    let
+      hasNetwork = container.network != null;
+      hasPod = container.pod != null;
+    in
+    {
+      inherit autoStart cmd environment environmentFiles image login;
+      dependsOn =
+        container.dependsOn ++
+        (if hasNetwork then [ "net-${container.network}" ] else [ ]) ++
+        (if hasPod then [ "pod-${container.pod}" ] else [ ]);
+      extraOptions =
+        container.extraOptions ++
+        (if hasNetwork then [ "--network=${container.network}" ] else [ ]) ++
+        (if hasPod then [ "--pod=${container.pod}" ] else [ ]);
+      /* ports are defined at the pod level */
+      ports = if hasPod then [ ] else map mkPortDef ports;
+      volumes = map (mkVolumeDef container) volumes;
+    };
 
   portOptions = {
-    options = {
-      host = mkOption { type = types.int; };
-      inner = mkOption { type = types.int; };
-    };
+    host = mkOption { type = types.int; };
+    inner = mkOption { type = types.int; };
   };
 
   volumeOptions = {
-    options = {
-      name = mkOption { type = types.nullOr types.str; default = null; };
-      host = mkOption { type = types.nullOr types.str; default = null; };
-      inner = mkOption { type = types.str; };
-    };
+    name = mkOption { type = types.nullOr types.str; default = null; };
+    host = mkOption { type = types.nullOr types.str; default = null; };
+    inner = mkOption { type = types.str; };
+  };
+
+  containerOptions = {
+    /* regular oci-containers */
+    autoStart = mkOption { type = types.bool; default = true; };
+    cmd = mkOption { type = types.listOf types.str; default = [ ]; };
+    dependsOn = mkOption { type = types.listOf types.str; default = [ ]; };
+    environment = mkOption { type = types.attrsOf types.str; default = { }; };
+    environmentFiles = mkOption { type = types.listOf types.path; default = [ ]; };
+    extraOptions = mkOption { type = types.listOf types.str; default = [ ]; };
+    image = mkOption { type = types.str; };
+    login.username = mkOption { type = types.nullOr types.str; default = null; };
+    login.passwordFile = mkOption { type = types.nullOr types.str; default = null; };
+    login.registry = mkOption { type = types.nullOr types.str; default = null; };
+    /* changed */
+    ports = mkOption { type = types.listOf (types.submodule { options = portOptions; }); default = [ ]; };
+    volumes = mkOption { type = types.listOf (types.submodule { options = volumeOptions; }); default = [ ]; };
+    /* new options */
+    pullOnStart = mkOption { type = types.bool; default = true; };
   };
 
   cfg = config.nixfiles.oci-containers;
+
+  allContainers =
+    let
+      mkPodContainer = podName: pod: containerName: container: nameValuePair "${podName}-${containerName}" (
+        container //
+        {
+          network = if cfg.backend == "docker" then podName else null;
+          pod = if cfg.backend == "docker" then null else podName;
+          volumeSubDir = pod.volumeSubDir;
+        }
+      );
+      podContainers = concatMapAttrs (podName: pod: mapAttrs' (mkPodContainer podName pod) pod.containers) cfg.pods;
+    in
+    attrsets.unionOfDisjoint cfg.containers podContainers;
 in
 {
   options.nixfiles.oci-containers = {
     backend = mkOption { type = types.enum [ "docker" "podman" ]; default = "docker"; };
     containers = mkOption {
       type = types.attrsOf (types.submodule ({ name, ... }: {
+        options =
+          containerOptions //
+          {
+            pod = mkOption { type = types.nullOr types.str; default = null; };
+            network = mkOption { type = types.nullOr types.str; default = null; };
+            volumeSubDir = mkOption { type = types.str; default = name; };
+          };
+      }));
+      default = { };
+    };
+    pods = mkOption {
+      type = types.attrsOf (types.submodule ({ name, ... }: {
         options = {
-          /* regular oci-containers */
-          autoStart = mkOption { type = types.bool; default = true; };
-          cmd = mkOption { type = types.listOf types.str; default = [ ]; };
-          dependsOn = mkOption { type = types.listOf types.str; default = [ ]; };
-          environment = mkOption { type = types.attrsOf types.str; default = { }; };
-          environmentFiles = mkOption { type = types.listOf types.path; default = [ ]; };
-          extraOptions = mkOption { type = types.listOf types.str; default = [ ]; };
-          image = mkOption { type = types.str; };
-          login.username = mkOption { type = types.nullOr types.str; default = null; };
-          login.passwordFile = mkOption { type = types.nullOr types.str; default = null; };
-          login.registry = mkOption { type = types.nullOr types.str; default = null; };
-          /* changed */
-          ports = mkOption { type = types.listOf (types.submodule portOptions); default = [ ]; };
-          volumes = mkOption { type = types.listOf (types.submodule volumeOptions); default = [ ]; };
-          /* new options */
-          pullOnStart = mkOption { type = types.bool; default = true; };
-          network = mkOption { type = types.nullOr types.str; default = null; };
+          containers = mkOption {
+            type = types.attrsOf (types.submodule { options = containerOptions; });
+            default = { };
+          };
           volumeSubDir = mkOption { type = types.str; default = name; };
         };
       }));
@@ -91,10 +143,11 @@ in
   config = {
     virtualisation.${cfg.backend}.autoPrune.enable = true;
     virtualisation.oci-containers.backend = cfg.backend;
-    virtualisation.oci-containers.containers = mapAttrs mkContainer cfg.containers;
+    virtualisation.oci-containers.containers = mapAttrs mkContainer allContainers;
     systemd.services = mkMerge [
-      (mapAttrs' mkPreStart (filterAttrs shouldPreStart cfg.containers))
-      (mapAttrs' mkNetworkService (filterAttrs shouldNetworkService cfg.containers))
+      (mapAttrs' mkPreStart (filterAttrs shouldPreStart allContainers))
+      (mapAttrs' mkNetworkService (filterAttrs shouldNetworkService allContainers))
+      (if cfg.backend == "podman" then mapAttrs' mkPodService cfg.pods else { })
     ];
   };
 }

--- a/shared/umami/default.nix
+++ b/shared/umami/default.nix
@@ -15,27 +15,27 @@ in
   };
 
   config = mkIf cfg.enable {
-    nixfiles.oci-containers.containers.umami = {
-      image = "ghcr.io/mikecao/umami:${cfg.umamiTag}";
-      environment = {
-        "DATABASE_URL" = "postgres://umami:umami@umami-db/umami";
+    nixfiles.oci-containers.pods.umami = {
+      containers = {
+        web = {
+          image = "ghcr.io/mikecao/umami:${cfg.umamiTag}";
+          environment = {
+            "DATABASE_URL" = "postgres://umami:umami@umami-db/umami";
+          };
+          environmentFiles = [ cfg.environmentFile ];
+          dependsOn = [ "umami-db" ];
+          ports = [{ host = cfg.port; inner = 3000; }];
+        };
+        db = {
+          image = "postgres:${cfg.postgresTag}";
+          environment = {
+            "POSTGRES_DB" = "umami";
+            "POSTGRES_USER" = "umami";
+            "POSTGRES_PASSWORD" = "umami";
+          };
+          volumes = [{ name = "pgdata"; inner = "/var/lib/postgresql/data"; }];
+        };
       };
-      environmentFiles = [ cfg.environmentFile ];
-      dependsOn = [ "umami-db" ];
-      network = "umami";
-      ports = [{ host = cfg.port; inner = 3000; }];
-    };
-
-    nixfiles.oci-containers.containers.umami-db = {
-      image = "postgres:${cfg.postgresTag}";
-      environment = {
-        "POSTGRES_DB" = "umami";
-        "POSTGRES_USER" = "umami";
-        "POSTGRES_PASSWORD" = "umami";
-      };
-      network = "umami";
-      volumes = [{ name = "pgdata"; inner = "/var/lib/postgresql/data"; }];
-      volumeSubDir = "umami";
     };
 
     nixfiles.backups.scripts.umami = ''


### PR DESCRIPTION
To migrate to podman I want my oci-containers lib to do all the heavy lifting.  Ideally, I'll be able to switch back and forth between podman and docker on a single host without breaking anything.

As part of that, add a 'pod' abstraction which groups containers together.  All containers in a pod share the same `volumeSubDir`.

With docker, pods are faked by putting the containers onto the same network.  But with podman they're true pods.