### PR TITLE
Backup script tweaks

### DIFF
--- a/shared/backups/default.nix
+++ b/shared/backups/default.nix
@@ -76,6 +76,15 @@ in
     enable = mkOption { type = types.bool; default = false; };
     scripts = mkOption { type = types.attrsOf types.str; default = { }; };
     pythonScripts = mkOption { type = types.attrsOf types.str; default = { }; };
+    sudoRules = mkOption {
+      type = types.listOf (types.submodule {
+        options = {
+          command = mkOption { type = types.str; };
+          runAs = mkOption { type = types.str; default = "ALL:ALL"; };
+        };
+      });
+      default = { };
+    };
     environmentFile = mkOption { type = types.str; };
     onCalendarFull = mkOption { type = types.str; default = "monthly"; };
     onCalendarIncr = mkOption { type = types.str; default = "Mon, 04:00"; };
@@ -97,5 +106,15 @@ in
       path = servicePath;
       serviceConfig = serviceConfig "incr";
     };
+
+    security.sudo.extraRules =
+      let
+        mkRule = rule: {
+          users = [ cfg.user ];
+          runAs = rule.runAs;
+          commands = [{ command = rule.command; options = [ "NOPASSWD" ]; }];
+        };
+      in
+      map mkRule cfg.sudoRules;
   };
 }

--- a/shared/bookdb/default.nix
+++ b/shared/bookdb/default.nix
@@ -64,12 +64,10 @@ in
     # package doesn't help - need the wrapper)
     nixfiles.backups.scripts.bookdb = ''
       /run/wrappers/bin/sudo tar cfz dump.tar.gz ${cfg.dataDir}
-      /run/wrappers/bin/sudo chown ${config.nixfiles.backups.user}.${config.nixfiles.backups.group} dump.tar.gz
       env ES_HOST=${config.systemd.services.bookdb.environment.ES_HOST} ${pkgs.nixfiles.bookdb}/bin/python -m bookdb.index.dump | gzip -9 > dump.json.gz
     '';
     nixfiles.backups.sudoRules = [
       { command = "${pkgs.gnutar}/bin/tar cfz dump.tar.gz ${cfg.dataDir}"; }
-      { command = "${pkgs.coreutils}/bin/chown ${config.nixfiles.backups.user}.${config.nixfiles.backups.group} dump.tar.gz"; }
     ];
   };
 }

--- a/shared/bookdb/default.nix
+++ b/shared/bookdb/default.nix
@@ -63,11 +63,11 @@ in
     # TODO: figure out how to get `sudo` in the unit's path (adding the
     # package doesn't help - need the wrapper)
     nixfiles.backups.scripts.bookdb = ''
-      /run/wrappers/bin/sudo tar cfz dump.tar.gz ${cfg.dataDir}
+      /run/wrappers/bin/sudo cp -a ${cfg.dataDir}/covers covers
       env ES_HOST=${config.systemd.services.bookdb.environment.ES_HOST} ${pkgs.nixfiles.bookdb}/bin/python -m bookdb.index.dump | gzip -9 > dump.json.gz
     '';
     nixfiles.backups.sudoRules = [
-      { command = "${pkgs.gnutar}/bin/tar cfz dump.tar.gz ${cfg.dataDir}"; }
+      { command = "${pkgs.coreutils}/bin/cp -a ${cfg.dataDir}/covers covers"; }
     ];
   };
 }

--- a/shared/bookdb/default.nix
+++ b/shared/bookdb/default.nix
@@ -67,14 +67,9 @@ in
       /run/wrappers/bin/sudo chown ${config.nixfiles.backups.user}.${config.nixfiles.backups.group} dump.tar.gz
       env ES_HOST=${config.systemd.services.bookdb.environment.ES_HOST} ${pkgs.nixfiles.bookdb}/bin/python -m bookdb.index.dump | gzip -9 > dump.json.gz
     '';
-    security.sudo.extraRules = [
-      {
-        users = [ config.nixfiles.backups.user ];
-        commands = [
-          { command = "${pkgs.gnutar}/bin/tar cfz dump.tar.gz ${cfg.dataDir}"; options = [ "NOPASSWD" ]; }
-          { command = "${pkgs.coreutils}/bin/chown ${config.nixfiles.backups.user}.${config.nixfiles.backups.group} dump.tar.gz"; options = [ "NOPASSWD" ]; }
-        ];
-      }
+    nixfiles.backups.sudoRules = [
+      { command = "${pkgs.gnutar}/bin/tar cfz dump.tar.gz ${cfg.dataDir}"; }
+      { command = "${pkgs.coreutils}/bin/chown ${config.nixfiles.backups.user}.${config.nixfiles.backups.group} dump.tar.gz"; }
     ];
   };
 }

--- a/shared/concourse/default.nix
+++ b/shared/concourse/default.nix
@@ -90,17 +90,11 @@ in
     nixfiles.backups.scripts.concourse = ''
       /run/wrappers/bin/sudo ${backend} exec -i concourse-db pg_dump -U concourse --no-owner concourse | gzip -9 > dump.sql.gz
     '';
-    security.sudo.extraRules = [
+    nixfiles.backups.sudoRules = [
       {
-        users = [ config.nixfiles.backups.user ];
-        commands = [
-          {
-            command =
-              let pkg = if backend == "docker" then pkgs.docker else pkgs.podman;
-              in "${pkg}/bin/${backend} exec -i concourse-db pg_dump -U concourse --no-owner concourse";
-            options = [ "NOPASSWD" ];
-          }
-        ];
+        command =
+          let pkg = if backend == "docker" then pkgs.docker else pkgs.podman;
+          in "${pkg}/bin/${backend} exec -i concourse-db pg_dump -U concourse --no-owner concourse";
       }
     ];
   };

--- a/shared/foundryvtt/default.nix
+++ b/shared/foundryvtt/default.nix
@@ -46,16 +46,11 @@ in
       /run/wrappers/bin/sudo chown ${config.nixfiles.backups.user}.${config.nixfiles.backups.group} dump.tar.gz
       /run/wrappers/bin/sudo systemctl start foundryvtt
     '';
-    security.sudo.extraRules = [
-      {
-        users = [ config.nixfiles.backups.user ];
-        commands = [
-          { command = "${pkgs.systemd}/bin/systemctl stop foundryvtt"; options = [ "NOPASSWD" ]; }
-          { command = "${pkgs.systemd}/bin/systemctl start foundryvtt"; options = [ "NOPASSWD" ]; }
-          { command = "${pkgs.gnutar}/bin/tar cfz dump.tar.gz ${cfg.dataDir}"; options = [ "NOPASSWD" ]; }
-          { command = "${pkgs.coreutils}/bin/chown ${config.nixfiles.backups.user}.${config.nixfiles.backups.group} dump.tar.gz"; options = [ "NOPASSWD" ]; }
-        ];
-      }
+    nixfiles.backups.sudoRules = [
+      { command = "${pkgs.systemd}/bin/systemctl stop foundryvtt"; }
+      { command = "${pkgs.systemd}/bin/systemctl start foundryvtt"; }
+      { command = "${pkgs.gnutar}/bin/tar cfz dump.tar.gz ${cfg.dataDir}"; }
+      { command = "${pkgs.coreutils}/bin/chown ${config.nixfiles.backups.user}.${config.nixfiles.backups.group} dump.tar.gz"; }
     ];
   };
 }

--- a/shared/foundryvtt/default.nix
+++ b/shared/foundryvtt/default.nix
@@ -42,13 +42,15 @@ in
     # package doesn't help - need the wrapper)
     nixfiles.backups.scripts.foundryvtt = ''
       /run/wrappers/bin/sudo systemctl stop foundryvtt
-      /run/wrappers/bin/sudo tar cfz dump.tar.gz ${cfg.dataDir}
+      /run/wrappers/bin/sudo tar cfz bin.tar.gz ${cfg.dataDir}/bin
+      /run/wrappers/bin/sudo cp -a ${cfg.dataDir}/data data
       /run/wrappers/bin/sudo systemctl start foundryvtt
     '';
     nixfiles.backups.sudoRules = [
       { command = "${pkgs.systemd}/bin/systemctl stop foundryvtt"; }
       { command = "${pkgs.systemd}/bin/systemctl start foundryvtt"; }
-      { command = "${pkgs.gnutar}/bin/tar cfz dump.tar.gz ${cfg.dataDir}"; }
+      { command = "${pkgs.gnutar}/bin/tar cfz bin.tar.gz ${cfg.dataDir}/bin"; }
+      { command = "${pkgs.coreutils}/bin/cp -a ${cfg.dataDir}/data data"; }
     ];
   };
 }

--- a/shared/foundryvtt/default.nix
+++ b/shared/foundryvtt/default.nix
@@ -43,14 +43,12 @@ in
     nixfiles.backups.scripts.foundryvtt = ''
       /run/wrappers/bin/sudo systemctl stop foundryvtt
       /run/wrappers/bin/sudo tar cfz dump.tar.gz ${cfg.dataDir}
-      /run/wrappers/bin/sudo chown ${config.nixfiles.backups.user}.${config.nixfiles.backups.group} dump.tar.gz
       /run/wrappers/bin/sudo systemctl start foundryvtt
     '';
     nixfiles.backups.sudoRules = [
       { command = "${pkgs.systemd}/bin/systemctl stop foundryvtt"; }
       { command = "${pkgs.systemd}/bin/systemctl start foundryvtt"; }
       { command = "${pkgs.gnutar}/bin/tar cfz dump.tar.gz ${cfg.dataDir}"; }
-      { command = "${pkgs.coreutils}/bin/chown ${config.nixfiles.backups.user}.${config.nixfiles.backups.group} dump.tar.gz"; }
     ];
   };
 }

--- a/shared/pleroma/default.nix
+++ b/shared/pleroma/default.nix
@@ -96,15 +96,11 @@ in
     nixfiles.backups.scripts.pleroma = ''
       /run/wrappers/bin/sudo cp -a ${config.users.users.pleroma.home}/uploads uploads
       /run/wrappers/bin/sudo cp -a ${config.users.users.pleroma.home}/static/emoji/custom emoji
-      /run/wrappers/bin/sudo chown -R ${config.nixfiles.backups.user}.${config.nixfiles.backups.group} uploads
-      /run/wrappers/bin/sudo chown -R ${config.nixfiles.backups.user}.${config.nixfiles.backups.group} emoji
       /run/wrappers/bin/sudo ${backend} exec -i pleroma-db pg_dump -U pleroma --no-owner -Fc pleroma > postgres.dump
     '';
     nixfiles.backups.sudoRules = [
       { command = "${pkgs.coreutils}/bin/cp -a ${config.users.users.pleroma.home}/uploads uploads"; }
       { command = "${pkgs.coreutils}/bin/cp -a ${config.users.users.pleroma.home}/static/emoji/custom emoji"; }
-      { command = "${pkgs.coreutils}/bin/chown -R ${config.nixfiles.backups.user}.${config.nixfiles.backups.group} uploads"; }
-      { command = "${pkgs.coreutils}/bin/chown -R ${config.nixfiles.backups.user}.${config.nixfiles.backups.group} emoji"; }
       {
         command =
           let pkg = if backend == "docker" then pkgs.docker else pkgs.podman;

--- a/shared/pleroma/default.nix
+++ b/shared/pleroma/default.nix
@@ -100,21 +100,15 @@ in
       /run/wrappers/bin/sudo chown -R ${config.nixfiles.backups.user}.${config.nixfiles.backups.group} emoji
       /run/wrappers/bin/sudo ${backend} exec -i pleroma-db pg_dump -U pleroma --no-owner -Fc pleroma > postgres.dump
     '';
-    security.sudo.extraRules = [
+    nixfiles.backups.sudoRules = [
+      { command = "${pkgs.coreutils}/bin/cp -a ${config.users.users.pleroma.home}/uploads uploads"; }
+      { command = "${pkgs.coreutils}/bin/cp -a ${config.users.users.pleroma.home}/static/emoji/custom emoji"; }
+      { command = "${pkgs.coreutils}/bin/chown -R ${config.nixfiles.backups.user}.${config.nixfiles.backups.group} uploads"; }
+      { command = "${pkgs.coreutils}/bin/chown -R ${config.nixfiles.backups.user}.${config.nixfiles.backups.group} emoji"; }
       {
-        users = [ config.nixfiles.backups.user ];
-        commands = [
-          { command = "${pkgs.coreutils}/bin/cp -a ${config.users.users.pleroma.home}/uploads uploads"; options = [ "NOPASSWD" ]; }
-          { command = "${pkgs.coreutils}/bin/cp -a ${config.users.users.pleroma.home}/static/emoji/custom emoji"; options = [ "NOPASSWD" ]; }
-          { command = "${pkgs.coreutils}/bin/chown -R ${config.nixfiles.backups.user}.${config.nixfiles.backups.group} uploads"; options = [ "NOPASSWD" ]; }
-          { command = "${pkgs.coreutils}/bin/chown -R ${config.nixfiles.backups.user}.${config.nixfiles.backups.group} emoji"; options = [ "NOPASSWD" ]; }
-          {
-            command =
-              let pkg = if backend == "docker" then pkgs.docker else pkgs.podman;
-              in "${pkg}/bin/${backend} exec -i pleroma-db pg_dump -U pleroma --no-owner -Fc pleroma";
-            options = [ "NOPASSWD" ];
-          }
-        ];
+        command =
+          let pkg = if backend == "docker" then pkgs.docker else pkgs.podman;
+          in "${pkg}/bin/${backend} exec -i pleroma-db pg_dump -U pleroma --no-owner -Fc pleroma";
       }
     ];
   };

--- a/shared/umami/default.nix
+++ b/shared/umami/default.nix
@@ -41,17 +41,11 @@ in
     nixfiles.backups.scripts.umami = ''
       /run/wrappers/bin/sudo ${backend} exec -i umami-db pg_dump -U umami --no-owner umami | gzip -9 > dump.sql.gz
     '';
-    security.sudo.extraRules = [
+    nixfiles.backups.sudoRules = [
       {
-        users = [ config.nixfiles.backups.user ];
-        commands = [
-          {
-            command =
-              let pkg = if backend == "docker" then pkgs.docker else pkgs.podman;
-              in "${pkg}/bin/${backend} exec -i umami-db pg_dump -U umami --no-owner umami";
-            options = [ "NOPASSWD" ];
-          }
-        ];
+        command =
+          let pkg = if backend == "docker" then pkgs.docker else pkgs.podman;
+          in "${pkg}/bin/${backend} exec -i umami-db pg_dump -U umami --no-owner umami";
       }
     ];
   };


### PR DESCRIPTION
Firstly, a little refactoring:

- Implicitly `chown` all backup subdirectories in the main script, so each separate script doesn't need to do that manually.
- Add a `nixfiles.backups.sudoRules` option which fills in the user and options automatically.

Then change the bookdb and foundryvtt scripts to be a bit more incremental-friendly by not targz-ing *everything*.