### PR TITLE
Always include sops configuration 

### DIFF
--- a/docs/src/runbooks/set-up-a-new-host.md
+++ b/docs/src/runbooks/set-up-a-new-host.md
@@ -113,8 +113,6 @@ creation_rules:
           - '<key>'
 ```
 
-Then enable secrets in the flake.nix.
-
 
 Optional: Configure alerting
 ----------------------------

--- a/docs/src/runbooks/set-up-a-new-host.md
+++ b/docs/src/runbooks/set-up-a-new-host.md
@@ -98,7 +98,7 @@ Optional: Configure secrets
 After first boot, generate an age public key from the host SSH key:
 
 ```bash
-nix-shell -p ssh-to-age --run 'ssh-keyscan <hostname>.barrucadu.co.uk | ssh-to-age'
+nix-shell -p ssh-to-age --run 'ssh-keyscan localhost | ssh-to-age'
 ```
 
 Add a new section with this key to `.sops.yaml`:

--- a/flake.nix
+++ b/flake.nix
@@ -25,26 +25,26 @@
 
       nixosConfigurations =
         let
-          mkNixosConfiguration = name: secrets: extraModules: nixpkgs.lib.nixosSystem {
+          mkNixosConfiguration = name: extraModules: nixpkgs.lib.nixosSystem {
             inherit system;
             specialArgs = { inherit flakeInputs; };
             modules = [
               {
                 networking.hostName = name;
                 nixpkgs.overlays = [ (_: _: { nixfiles = self.packages.${system}; }) ];
+                sops.defaultSopsFile = ./hosts + "/${name}" + /secrets.yaml;
               }
               ./shared
-              # nix-linter doesn't support the ./hosts/${name}/foo.nix syntax yet
               (./hosts + "/${name}" + /configuration.nix)
               (./hosts + "/${name}" + /hardware.nix)
-            ] ++ extraModules ++
-            (if secrets then [ sops-nix.nixosModules.sops { sops.defaultSopsFile = ./hosts + "/${name}" + /secrets.yaml; } ] else [ ]);
+              sops-nix.nixosModules.sops
+            ] ++ extraModules;
           };
         in
         {
-          azathoth = mkNixosConfiguration "azathoth" false [ "${nixpkgs}/nixos/modules/installer/scan/not-detected.nix" ];
-          carcosa = mkNixosConfiguration "carcosa" true [ "${nixpkgs}/nixos/modules/profiles/qemu-guest.nix" ];
-          nyarlathotep = mkNixosConfiguration "nyarlathotep" true [ "${nixpkgs}/nixos/modules/installer/scan/not-detected.nix" ];
+          azathoth = mkNixosConfiguration "azathoth" [ "${nixpkgs}/nixos/modules/installer/scan/not-detected.nix" ];
+          carcosa = mkNixosConfiguration "carcosa" [ "${nixpkgs}/nixos/modules/profiles/qemu-guest.nix" ];
+          nyarlathotep = mkNixosConfiguration "nyarlathotep" [ "${nixpkgs}/nixos/modules/installer/scan/not-detected.nix" ];
         };
 
       packages.${system} =


### PR DESCRIPTION
This is fine because the secrets.yaml and sops configuration only needs
to exist if you actually try to use the secrets.