### PR TITLE
Upgrade concourse to postgres 16

### DIFF
--- a/shared/concourse/options.nix
+++ b/shared/concourse/options.nix
@@ -46,7 +46,7 @@ with lib;
 
     postgresTag = mkOption {
       type = types.str;
-      default = "13";
+      default = "16";
       description = mdDoc ''
         Tag to use of the `postgres` container image.
       '';


### PR DESCRIPTION
This has been manually applied to carcosa.