### PR TITLE
Make `sudo` paths explicit

### DIFF
--- a/hosts/carcosa/configuration.nix
+++ b/hosts/carcosa/configuration.nix
@@ -412,8 +412,8 @@ in
             exit 1
           fi
 
-          /run/wrappers/bin/sudo rsync -a --delete ~/bookdb-covers/ ${config.nixfiles.bookdb.dataDir}/covers || exit 1
-          /run/wrappers/bin/sudo chown -R ${config.users.users.bookdb.name}.nogroup ${config.nixfiles.bookdb.dataDir}/covers || exit 1
+          /run/wrappers/bin/sudo ${pkgs.rsync}/bin/rsync -a --delete ~/bookdb-covers/ ${config.nixfiles.bookdb.dataDir}/covers || exit 1
+          /run/wrappers/bin/sudo ${pkgs.coreutils}/bin/chown -R ${config.users.users.bookdb.name}.nogroup ${config.nixfiles.bookdb.dataDir}/covers || exit 1
         '';
         bookdb-receive-elasticsearch = ''
           env ES_HOST=${config.systemd.services.bookdb.environment.ES_HOST} \
@@ -438,7 +438,7 @@ in
       users = [ config.users.extraUsers.nyarlathotep-remote-sync.name ];
       commands = [
         { command = "${pkgs.rsync}/bin/rsync -a --delete ${config.users.extraUsers.nyarlathotep-remote-sync.home}/bookdb-covers/ ${config.nixfiles.bookdb.dataDir}/covers"; options = [ "NOPASSWD" ]; }
-        { command = "${pkgs.coreutils-full}/bin/chown -R ${config.users.users.bookdb.name}.nogroup ${config.nixfiles.bookdb.dataDir}/covers"; options = [ "NOPASSWD" ]; }
+        { command = "${pkgs.coreutils}/bin/chown -R ${config.users.users.bookdb.name}.nogroup ${config.nixfiles.bookdb.dataDir}/covers"; options = [ "NOPASSWD" ]; }
       ];
     }
   ];

--- a/hosts/nyarlathotep/configuration.nix
+++ b/hosts/nyarlathotep/configuration.nix
@@ -475,8 +475,8 @@ in
       ExecStart = pkgs.writeShellScript "bookdb-sync" ''
         set -ex
 
-        /run/wrappers/bin/sudo cp -r ${config.nixfiles.bookdb.dataDir}/covers/ ~/bookdb-covers
-        trap "/run/wrappers/bin/sudo rm -rf ~/bookdb-covers" EXIT
+        /run/wrappers/bin/sudo ${pkgs.coreutils}/bin/cp -r ${config.nixfiles.bookdb.dataDir}/covers/ ~/bookdb-covers
+        trap "/run/wrappers/bin/sudo ${pkgs.coreutils}/bin/rm -rf ~/bookdb-covers" EXIT
         rsync -az\
               -e "ssh -i $SSH_KEY_FILE -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no" \
               ~/bookdb-covers/ \

--- a/shared/bookdb/default.nix
+++ b/shared/bookdb/default.nix
@@ -67,7 +67,7 @@ in
     # TODO: figure out how to get `sudo` in the unit's path (adding the
     # package doesn't help - need the wrapper)
     nixfiles.backups.scripts.bookdb = ''
-      /run/wrappers/bin/sudo cp -a ${cfg.dataDir}/covers covers
+      /run/wrappers/bin/sudo ${pkgs.coreutils}/bin/cp -a ${cfg.dataDir}/covers covers
       env ES_HOST=${config.systemd.services.bookdb.environment.ES_HOST} ${pkgs.nixfiles.bookdb}/bin/python -m bookdb.index.dump | gzip -9 > dump.json.gz
     '';
     nixfiles.backups.sudoRules = [

--- a/shared/foundryvtt/default.nix
+++ b/shared/foundryvtt/default.nix
@@ -47,10 +47,10 @@ in
     # TODO: figure out how to get `sudo` in the unit's path (adding the
     # package doesn't help - need the wrapper)
     nixfiles.backups.scripts.foundryvtt = ''
-      /run/wrappers/bin/sudo systemctl stop foundryvtt
-      /run/wrappers/bin/sudo tar cfz bin.tar.gz ${cfg.dataDir}/bin
-      /run/wrappers/bin/sudo cp -a ${cfg.dataDir}/data data
-      /run/wrappers/bin/sudo systemctl start foundryvtt
+      /run/wrappers/bin/sudo ${pkgs.systemd}/bin/systemctl stop foundryvtt
+      /run/wrappers/bin/sudo ${pkgs.gnutar}/bin/tar cfz bin.tar.gz ${cfg.dataDir}/bin
+      /run/wrappers/bin/sudo ${pkgs.coreutils}/bin/cp -a ${cfg.dataDir}/data data
+      /run/wrappers/bin/sudo ${pkgs.systemd}/bin/systemctl start foundryvtt
     '';
     nixfiles.backups.sudoRules = [
       { command = "${pkgs.systemd}/bin/systemctl stop foundryvtt"; }


### PR DESCRIPTION
bookdb-sync mysteriously broke, due to a path changing.  Avoid that, and similar problems, by being explicit about all the paths of sudo-ed things.