### PR TITLE
Bump umami to v2.9.0

### DIFF
--- a/shared/umami/options.nix
+++ b/shared/umami/options.nix
@@ -30,7 +30,7 @@ with lib;
 
     umamiTag = mkOption {
       type = types.str;
-      default = "postgresql-v1.40";
+      default = "postgresql-v2.9.0";
       description = mdDoc ''
         Tag to use of the `ghcr.io/umami-software/umami` container image.
       '';


### PR DESCRIPTION
I have run the data migration script manually, see https://umami.is/docs/migrate-v1-v2