### PR TITLE
[nyarlathotep] Netwoking changes for thing-doer

### DIFF
--- a/hosts/nyarlathotep/configuration.nix
+++ b/hosts/nyarlathotep/configuration.nix
@@ -58,6 +58,31 @@ in
   nixfiles.eraseYourDarlings.barrucaduPasswordFile = config.sops.secrets."users/barrucadu".path;
   sops.secrets."users/barrucadu".neededForUsers = true;
 
+  # Set up a bridge network so that VMs can connect to the LAN
+  #
+  # `enp8s0` is the physical ethernet interface, but I am slaving that to the
+  # `br0` bridge - so it's the bridge's MAC address that gets presented to the
+  # physical network.
+  #
+  # To avoid having to reconfigure static IP assignments in my router if I
+  # switch between bridged and non-bridged networking, set up the MAC addresses
+  # such that:
+  #
+  # - `br0` has the MAC address of the physical ethernet card
+  # - `enp8s0` has a new random MAC address (https://serverfault.com/a/631119)
+  #
+  # So if I delete this block, the MAC address the router sees is unchanged, and
+  # so the static IP assignment is unaffected.
+  networking.useDHCP = false;
+  networking.interfaces.br0 = {
+    useDHCP = true;
+    macAddress = "a0:36:bc:bb:65:8d";
+  };
+  networking.interfaces.enp8s0 = {
+    macAddress = "92:0b:e6:21:86:99";
+    useDHCP = true;
+  };
+  networking.bridges.br0.interfaces = [ "enp8s0" ];
 
   ###############################################################################
   ## Backups

--- a/hosts/nyarlathotep/configuration.nix
+++ b/hosts/nyarlathotep/configuration.nix
@@ -90,6 +90,7 @@ in
   ###############################################################################
 
   nixfiles.resolved.enable = true;
+  nixfiles.resolved.address = "10.0.0.3:53";
   nixfiles.resolved.cacheSize = 1000000;
   nixfiles.resolved.hostsDirs = [ "/etc/dns/hosts" ];
   nixfiles.resolved.zonesDirs = [ "/etc/dns/zones" ];


### PR DESCRIPTION
This PR binds `resolved` to 10.0.0.3 rather than 0.0.0.0, so I can run the thing-doer DNS server on an internal interface.  It also sets up a bridge network to the LAN so I can spin up VMs which get assigned LAN IP addresses.