### PR TITLE
Enable oci-container backend service always

### DIFF
--- a/shared/oci-containers/default.nix
+++ b/shared/oci-containers/default.nix
@@ -104,9 +104,16 @@ in
   ];
 
   config = {
-    virtualisation.${cfg.backend}.autoPrune.enable = true;
-    virtualisation.oci-containers.backend = cfg.backend;
-    virtualisation.oci-containers.containers = mapAttrs mkContainer allContainers;
+    virtualisation.${cfg.backend} = {
+      enable = true;
+      autoPrune.enable = true;
+    };
+
+    virtualisation.oci-containers = {
+      backend = cfg.backend;
+      containers = mapAttrs mkContainer allContainers;
+    };
+
     systemd.services = mkMerge [
       (mapAttrs' mkPreStart (filterAttrs shouldPreStart allContainers))
       (mapAttrs' mkNetworkService (filterAttrs shouldNetworkService allContainers))


### PR DESCRIPTION
The NixOS module only enabled the service if there are containers, but that means I have different podman config on azathoth and nyarlathotep, as the former has no containers.  That kind of sucks, so just always enable it.