### PR TITLE
README.markdown: Link to new NixOS wiki

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -16,7 +16,7 @@ nix run .#lint
 See [the documentation](https://nixfiles.docs.barrucadu.co.uk).
 
 [NixOS]: https://nixos.org
-[flakes]: https://nixos.wiki/wiki/Flakes
+[flakes]: https://wiki.nixos.org/wiki/Flakes
 
 
 Overview


### PR DESCRIPTION
This commit updates the the link from the former, unofficial nixos wiki page to the new https://wiki.nixos.org

ref: NixOS/foundation#113