### PR TITLE
Bump flake.lock & pin oxalica/rust-overlay

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -13,11 +13,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1715237858,
-        "narHash": "sha256-2UdDTeUtmVkzswS/8ql7Sa+LD2UWP0rXnhYHg7hHfO8=",
+        "lastModified": 1715818407,
+        "narHash": "sha256-mJWD7Z/4c7Kse57nG7gFaJumlzB5keeb4zkqUEImTQo=",
         "owner": "barrucadu",
         "repo": "bookdb",
-        "rev": "7edef34f315d4e01536bc96ff9ae875e2190afda",
+        "rev": "f24235749d9b414b1af587b6496af5341d81d36b",
         "type": "github"
       },
       "original": {
@@ -39,11 +39,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1715202300,
-        "narHash": "sha256-RvT2ByuiU1ULhczRVPyCdm0IvaXvV39cDZg5SV8E5Nw=",
+        "lastModified": 1715805076,
+        "narHash": "sha256-OzKD0KZHW1L9JUD77x40CVcfUJtNVI08OR5vvEo0SOQ=",
         "owner": "barrucadu",
         "repo": "bookmarks",
-        "rev": "2ef386d15eadd73b694d24890135bc63b95e4613",
+        "rev": "e2ba9f0a9907aab5cd6d1782f15a00b6cabdc2e5",
         "type": "github"
       },
       "original": {
@@ -92,11 +92,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1715542476,
-        "narHash": "sha256-FF593AtlzQqa8JpzrXyRws4CeKbc5W86o8tHt4nRfIg=",
+        "lastModified": 1716061101,
+        "narHash": "sha256-H0eCta7ahEgloGIwE/ihkyGstOGu+kQwAiHvwVoXaA0=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "44072e24566c5bcc0b7aa9178a0104f4cfffab19",
+        "rev": "e7cc61784ddf51c81487637b3031a6dd2d6673a2",
         "type": "github"
       },
       "original": {
@@ -116,11 +116,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1714728014,
-        "narHash": "sha256-Gv0a6WNoSKmTAlDSuua9Uvd64+GEmTWHHEKQtAoVvhg=",
+        "lastModified": 1715878782,
+        "narHash": "sha256-oJ1S84Le6iq0aKqaaxTJwGRmHtARiPD68a0HNMWS6CM=",
         "owner": "barrucadu",
         "repo": "prometheus-awair-exporter",
-        "rev": "63e5d8a35b17201175a2783976146fb97c22994c",
+        "rev": "63a75df0c6fa317729f35a9d0834d226a28cd5f4",
         "type": "github"
       },
       "original": {
@@ -142,11 +142,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1714723930,
-        "narHash": "sha256-gr8MiHzCS+VPq09VlpPpeZlSW63KJ5u/CB/OEhITnBY=",
+        "lastModified": 1715878797,
+        "narHash": "sha256-n0xB6EOsS8wMTq8TK48RCKUwTT15qyR2hheANK0jZ6M=",
         "owner": "barrucadu",
         "repo": "resolved",
-        "rev": "66fb9a30822aa2c1e220bd56250bbd4eb97311fb",
+        "rev": "a89e9f7eab4edd42537387c09eae10d6eedac736",
         "type": "github"
       },
       "original": {
@@ -185,6 +185,7 @@
       "original": {
         "owner": "oxalica",
         "repo": "rust-overlay",
+        "rev": "1d8fcbbfcfd3476c2665384a46ee9d07ef2b4dd9",
         "type": "github"
       }
     },
@@ -198,11 +199,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1715482972,
-        "narHash": "sha256-y1uMzXNlrVOWYj1YNcsGYLm4TOC2aJrwoUY1NjQs9fM=",
+        "lastModified": 1716087663,
+        "narHash": "sha256-zuSAGlx8Qk0OILGCC2GUyZ58/SJ5R3GZdeUNQ6IS0fQ=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "b6cb5de2ce57acb10ecdaaf9bbd62a5ff24fa02e",
+        "rev": "0bf1808e70ce80046b0cff821c019df2b19aabf5",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -35,7 +35,7 @@
       inputs.nixpkgs.follows = "nixpkgs";
     };
     rust-overlay = {
-      url = "github:oxalica/rust-overlay";
+      url = "github:oxalica/rust-overlay/1d8fcbbfcfd3476c2665384a46ee9d07ef2b4dd9";
       inputs.nixpkgs.follows = "nixpkgs";
     };
   };


### PR DESCRIPTION
With the newest rust-overlay, bookdb & bookmarks are missing openssl at runtime.