### PR TITLE
[nyarlathotep] Load victoriametrics data after boot

### DIFF
--- a/hosts/nyarlathotep/configuration.nix
+++ b/hosts/nyarlathotep/configuration.nix
@@ -477,6 +477,8 @@ in
       VICTORIAMETRICS_URI = "http://${config.services.victoriametrics.listenAddress}";
     };
   };
+  # also reload data after boot
+  systemd.timers.hledger-export-to-victoriametrics.timerConfig.OnBootSec = "5m";
 
   services.victoriametrics = {
     enable = true;


### PR DESCRIPTION
It's not persisted, so it's lost on boot.

5m is too long a delay, it could probably be 1m, but nyarlathotep only reboots in the early hours of the morning so I'm not too concerned with getting the data ASAP.