### PR TITLE
[carcosa / yuggoth] Configure remote builds

### DIFF
--- a/hosts/carcosa/configuration.nix
+++ b/hosts/carcosa/configuration.nix
@@ -345,6 +345,8 @@ in
     isSystemUser = true;
     shell = pkgs.bashInteractive;
     group = "nogroup";
+    openssh.authorizedKeys.keys =
+      [ "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIHFzMpx7QNSAb5tCbkzMRIG62PvBZysflwwCKchFDHtY nix@yuggoth" ];
   };
   nix.settings.trusted-users = [ config.users.extraUsers.nix-remote-builder.name ];
 

--- a/hosts/carcosa/configuration.nix
+++ b/hosts/carcosa/configuration.nix
@@ -334,6 +334,21 @@ in
   nixfiles.bookmarks.remoteSync.receive.authorizedKeys =
     [ "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIChVw9DPLafA3lCLCI4Df9rYuxedFQTXAwDOOHUfZ0Ac remote-sync@nyarlathotep" ];
 
+
+  ###############################################################################
+  ## Remote Builds
+  ###############################################################################
+
+  users.extraUsers.nix-remote-builder = {
+    home = "/var/lib/nix-remote-builder";
+    createHome = true;
+    isSystemUser = true;
+    shell = pkgs.bashInteractive;
+    group = "nogroup";
+  };
+  nix.settings.trusted-users = [ config.users.extraUsers.nix-remote-builder.name ];
+
+
   ###############################################################################
   ## Miscellaneous
   ###############################################################################

--- a/hosts/yuggoth/configuration.nix
+++ b/hosts/yuggoth/configuration.nix
@@ -48,4 +48,20 @@ with lib;
   nixfiles.bookmarks.remoteSync.receive.enable = true;
   nixfiles.bookmarks.remoteSync.receive.authorizedKeys =
     [ "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIChVw9DPLafA3lCLCI4Df9rYuxedFQTXAwDOOHUfZ0Ac remote-sync@nyarlathotep" ];
+
+  ###############################################################################
+  ## Remote Builds
+  ###############################################################################
+
+  nix.distributedBuilds = true;
+  nix.buildMachines = [{
+    hostName = "carcosa.barrucadu.co.uk";
+    system = "x86_64-linux";
+    sshUser = "nix-remote-builder";
+    sshKey = config.sops.secrets."nix/build_machines/carcosa/ssh_key".path;
+    publicHostKey = "c3NoLWVkMjU1MTkgQUFBQUMzTnphQzFsWkRJMU5URTVBQUFBSUlTa0x0bk11bUs3N1RYUHBSa0VCeGI1NEtZVHZMZzhHUmFOeGl6c2NoMSsgcm9vdEBjYXJjb3NhCg==";
+    protocol = "ssh-ng";
+    maxJobs = 8;
+  }];
+  sops.secrets."nix/build_machines/carcosa/ssh_key" = { };
 }

--- a/hosts/yuggoth/secrets.yaml
+++ b/hosts/yuggoth/secrets.yaml
@@ -1,3 +1,7 @@
+nix:
+    build_machines:
+        carcosa:
+            ssh_key: ENC[AES256_GCM,data:iHdR8yErpDSh9GHQ1nS1u6jkxDxDoQnjpElKlE51W4zP/0Aswvok9cgIhMEvr6fEhQlHYJm+naLmLg+r96EPgTHOOiR+Hz722EDor/BhQoAUn+ebWm6HshoL2xZNjg60gFR6Ac7m7s9kgA+LIxKcPW6U53EVBo9yeVRvHxBUrMfzyjmbB0kP3tiomwNgcsVjrg4SDss3AoYlfsq5TkYr4m6XRXYuM5tQxpFelSSGKDCYMKhS0UKP5diQz2GVvlbYkF7wOMHTnb4hn67p5AbesNiPHatIvUmm6upi+BIQYxcB4T0r9NzFmvqKkFiiFXZJ/IWuMiVP0uklccfkWarHa07S0JZlBMwGPgn7Nt2NesNWYsNqdiDit7Wbv/zCkOUo+BP3EWAZTLne4VjLfDzPXVFz2+z/ukPIpK0QYk9bwfR1VJAa6ahhRwJ6elNApaZhoFRbh4FCWjGQbpnHWt658q3d4GPe+gWapJuG4RtYGYPSxmpq3BXw+FsVyF2CJD6IAPpP4+xpVLoXRkpQyojOO8P4uZK0g5UYL/ap,iv:pUzTPINBp+AdZTy8Dk4t6+wODlJZZ1V/AJD51oVNIi4=,tag:hmtRHuX0H29lGTzwfqsz1g==,type:str]
 users:
     barrucadu: ENC[AES256_GCM,data:AydpgRw6tSPNsj0YJgNKDIwcCF2bo+vwJhrRJhbeJAY39yJHlP9xTarGGNBAczrKBwKKMN2EAA27hRyX+tDc/ne9mtOx4P5JS86mN9wkLKpaHbIamJNGfatDlu3uBvStNIKSC/CrnsFZ,iv:fW5+OJ2O8R9VB6YmKUP3jmKOHDEtZ4fBsVUmqbrkPjw=,tag:N04QCMG9/WV10Sd1lgGzhA==,type:str]
 services:
@@ -27,8 +31,8 @@ sops:
             NVBIU1I2MDRqVGt3eGRzbjdDb0d5Yk0KGPo6sIu5pp6s1r/IhyNjfNgDwxl3SWM3
             TMmIsx3iHsy+xgxUuGQXCsUkCy4YBzEjRVVtycCRfd5IAXryGhHEuQ==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2024-12-10T21:54:13Z"
-    mac: ENC[AES256_GCM,data:oOdA0OIYr7LBbzVXon1xSE3sgQbjKAFQH9X2TVAeBwVOvvfdYF3fzjApZnkXA5DCCqnNwt9uLrsASjsaIQadbvpsq72S9WKY+M1jDHUQTRlLmL4V/ptEQ4gmY5ik1BBH6OQdYl44ZTG2JadpkQTH/SVQJrH3BMz6r30398VGHyM=,iv:RtRsvv0vEsfckNQ4ipoK5DhurlHlb6zLF2iMuCbLg9I=,tag:zRdJhrlur3HnXexbvVA+FA==,type:str]
+    lastmodified: "2024-12-11T12:37:28Z"
+    mac: ENC[AES256_GCM,data:rUwFjbtGgI65WseQ87YImuQHfjG+yOV64/ove33Ucp8G/88xFdYSRdHuL7buPBfIHvQygOb+7nzHiHOzQ6SrnbOQlSOe5ZotxOpLqLHcteA42HoXpcJKwHhpBjE7OiHRjVbh4tVlYKgeMKRS5FV4gvgj9r+noxgmUOek2NGg5i0=,iv:pZJ/nMvvMDCx8OP42Wvf7zHjMle7xd99oH2Y12IpiEw=,tag:/BJ0pg3tAvtEoWvOQiN4cg==,type:str]
     pgp: []
     unencrypted_suffix: _unencrypted
     version: 3.8.1


### PR DESCRIPTION
This will let me drop yuggoth down to the smallest instance type, as I no longer need to be able to compile bookdb and bookmarks locally.