### PR TITLE
Remove uses of deprecated `mdDoc`

### DIFF
--- a/shared/bookdb/options.nix
+++ b/shared/bookdb/options.nix
@@ -7,7 +7,7 @@ with lib;
     enable = mkOption {
       type = types.bool;
       default = false;
-      description = mdDoc ''
+      description = ''
         Enable the [bookdb](https://github.com/barrucadu/bookdb) service.
       '';
     };
@@ -15,7 +15,7 @@ with lib;
     port = mkOption {
       type = types.int;
       default = 46667;
-      description = mdDoc ''
+      description = ''
         Port (on 127.0.0.1) to expose bookdb on.
       '';
     };
@@ -23,7 +23,7 @@ with lib;
     elasticsearchPort = mkOption {
       type = types.int;
       default = 47164;
-      description = mdDoc ''
+      description = ''
         Port (on 127.0.0.1) to expose the elasticsearch container on.
       '';
     };
@@ -31,7 +31,7 @@ with lib;
     elasticsearchTag = mkOption {
       type = types.str;
       default = "8.0.0";
-      description = mdDoc ''
+      description = ''
         Tag to use of the `elasticsearch` container image.
       '';
     };
@@ -39,7 +39,7 @@ with lib;
     readOnly = mkOption {
       type = types.bool;
       default = false;
-      description = mdDoc ''
+      description = ''
         Launch the service in "read-only" mode.  Enable this if exposing it to a
         public network.
       '';
@@ -48,7 +48,7 @@ with lib;
     dataDir = mkOption {
       type = types.str;
       default = "/srv/bookdb";
-      description = mdDoc ''
+      description = ''
         Directory to store uploaded files to.
 
         If the `erase-your-darlings` module is enabled, this is overridden to be
@@ -59,7 +59,7 @@ with lib;
     logLevel = mkOption {
       type = types.str;
       default = "info";
-      description = mdDoc ''
+      description = ''
         Verbosity of the log messages.
       '';
     };
@@ -67,7 +67,7 @@ with lib;
     logFormat = mkOption {
       type = types.str;
       default = "json,no-time";
-      description = mdDoc ''
+      description = ''
         Format of the log messages.
       '';
     };
@@ -77,14 +77,14 @@ with lib;
         enable = mkOption {
           type = types.bool;
           default = false;
-          description = mdDoc ''
+          description = ''
             Enable receiving push-based remote sync from other hosts.
           '';
         };
         authorizedKeys = mkOption {
           type = types.listOf types.str;
           default = [ ];
-          description = mdDoc ''
+          description = ''
             SSH public keys to allow pushes from.
           '';
         };
@@ -94,20 +94,20 @@ with lib;
         enable = mkOption {
           type = types.bool;
           default = false;
-          description = mdDoc ''
+          description = ''
             Enable periodically pushing local state to other hosts.
           '';
         };
         sshKeyFile = mkOption {
           type = types.str;
-          description = mdDoc ''
+          description = ''
             Path to SSH private key.
           '';
         };
         targets = mkOption {
           type = types.listOf types.str;
           default = [ ];
-          description = mdDoc ''
+          description = ''
             Hosts to push to.
           '';
         };

--- a/shared/bookmarks/options.nix
+++ b/shared/bookmarks/options.nix
@@ -7,7 +7,7 @@ with lib;
     enable = mkOption {
       type = types.bool;
       default = false;
-      description = mdDoc ''
+      description = ''
         Enable the [bookmarks](https://github.com/barrucadu/bookmarks) service.
       '';
     };
@@ -15,7 +15,7 @@ with lib;
     port = mkOption {
       type = types.int;
       default = 48372;
-      description = mdDoc ''
+      description = ''
         Port (on 127.0.0.1) to expose bookmarks on.
       '';
     };
@@ -23,7 +23,7 @@ with lib;
     elasticsearchPort = mkOption {
       type = types.int;
       default = 43389;
-      description = mdDoc ''
+      description = ''
         Port (on 127.0.0.1) to expose the elasticsearch container on.
       '';
     };
@@ -31,7 +31,7 @@ with lib;
     elasticsearchTag = mkOption {
       type = types.str;
       default = "8.0.0";
-      description = mdDoc ''
+      description = ''
         Tag to use of the `elasticsearch` container image.
       '';
     };
@@ -39,7 +39,7 @@ with lib;
     readOnly = mkOption {
       type = types.bool;
       default = false;
-      description = mdDoc ''
+      description = ''
         Launch the service in "read-only" mode.  Enable this if exposing it to a
         public network.
       '';
@@ -48,7 +48,7 @@ with lib;
     logLevel = mkOption {
       type = types.str;
       default = "info";
-      description = mdDoc ''
+      description = ''
         Verbosity of the log messages.
       '';
     };
@@ -56,7 +56,7 @@ with lib;
     logFormat = mkOption {
       type = types.str;
       default = "json,no-time";
-      description = mdDoc ''
+      description = ''
         Format of the log messages.
       '';
     };
@@ -66,14 +66,14 @@ with lib;
         enable = mkOption {
           type = types.bool;
           default = false;
-          description = mdDoc ''
+          description = ''
             Enable receiving push-based remote sync from other hosts.
           '';
         };
         authorizedKeys = mkOption {
           type = types.listOf types.str;
           default = [ ];
-          description = mdDoc ''
+          description = ''
             SSH public keys to allow pushes from.
           '';
         };
@@ -83,20 +83,20 @@ with lib;
         enable = mkOption {
           type = types.bool;
           default = false;
-          description = mdDoc ''
+          description = ''
             Enable periodically pushing local state to other hosts.
           '';
         };
         sshKeyFile = mkOption {
           type = types.str;
-          description = mdDoc ''
+          description = ''
             Path to SSH private key.
           '';
         };
         targets = mkOption {
           type = types.listOf types.str;
           default = [ ];
-          description = mdDoc ''
+          description = ''
             Hosts to push to.
           '';
         };

--- a/shared/concourse/options.nix
+++ b/shared/concourse/options.nix
@@ -7,7 +7,7 @@ with lib;
     enable = mkOption {
       type = types.bool;
       default = false;
-      description = mdDoc ''
+      description = ''
         Enable the [Concourse CI](https://concourse-ci.org/) service.
       '';
     };
@@ -15,7 +15,7 @@ with lib;
     concourseTag = mkOption {
       type = types.str;
       default = "7.11.2";
-      description = mdDoc ''
+      description = ''
         Tag to use of the `concourse/concourse` container image.
       '';
     };
@@ -23,7 +23,7 @@ with lib;
     githubUser = mkOption {
       type = types.str;
       default = "barrucadu";
-      description = mdDoc ''
+      description = ''
         The GitHub user to authenticate with.
       '';
     };
@@ -31,7 +31,7 @@ with lib;
     port = mkOption {
       type = types.int;
       default = 46498;
-      description = mdDoc ''
+      description = ''
         Port (on 127.0.0.1) to expose Concourse CI on.
       '';
     };
@@ -39,7 +39,7 @@ with lib;
     metricsPort = mkOption {
       type = types.int;
       default = 45811;
-      description = mdDoc ''
+      description = ''
         Port (on 127.0.0.1) to expose the Prometheus metrics on.
       '';
     };
@@ -47,7 +47,7 @@ with lib;
     postgresTag = mkOption {
       type = types.str;
       default = "16";
-      description = mdDoc ''
+      description = ''
         Tag to use of the `postgres` container image.
       '';
     };
@@ -55,7 +55,7 @@ with lib;
     workerScratchDir = mkOption {
       type = types.nullOr types.path;
       default = null;
-      description = mdDoc ''
+      description = ''
         Mount a directory from the host into the worker container to use as
         temporary storage.  This is useful if the filesystem used for container
         volumes isn't very big.
@@ -64,7 +64,7 @@ with lib;
 
     environmentFile = mkOption {
       type = types.str;
-      description = mdDoc ''
+      description = ''
         Environment file to pass secrets into the service.  This is of the form:
 
         ```text

--- a/shared/erase-your-darlings/options.nix
+++ b/shared/erase-your-darlings/options.nix
@@ -7,7 +7,7 @@ with lib;
     enable = mkOption {
       type = types.bool;
       default = false;
-      description = mdDoc ''
+      description = ''
         Enable wiping `/` on boot and storing persistent data in
         `''${persistDir}`.
       '';
@@ -15,7 +15,7 @@ with lib;
 
     barrucaduPasswordFile = mkOption {
       type = types.str;
-      description = mdDoc ''
+      description = ''
         File containing the hashed password for `barrucadu`.
 
         If using [sops-nix](https://github.com/Mic92/sops-nix) set the
@@ -26,7 +26,7 @@ with lib;
     rootSnapshot = mkOption {
       type = types.str;
       default = "local/volatile/root@blank";
-      description = mdDoc ''
+      description = ''
         ZFS snapshot to roll back to on boot.
       '';
     };
@@ -34,7 +34,7 @@ with lib;
     persistDir = mkOption {
       type = types.path;
       default = "/persist";
-      description = mdDoc ''
+      description = ''
         Persistent directory which will not be erased.  This must be on a
         different ZFS dataset that will not be wiped when rolling back to the
         `rootSnapshot`.
@@ -46,7 +46,7 @@ with lib;
     machineId = mkOption {
       type = types.str;
       example = "64b1b10f3bef4616a7faf5edf1ef3ca5";
-      description = mdDoc ''
+      description = ''
         An arbitrary 32-character hexadecimal string, used to identify the host.
         This is needed for journalctl logs from previous boots to be accessible.
 

--- a/shared/finder/options.nix
+++ b/shared/finder/options.nix
@@ -7,14 +7,14 @@ with lib;
     enable = mkOption {
       type = types.bool;
       default = false;
-      description = mdDoc ''
+      description = ''
         Enable the finder service.
       '';
     };
 
     image = mkOption {
       type = types.str;
-      description = mdDoc ''
+      description = ''
         Container image to run.
       '';
     };
@@ -22,7 +22,7 @@ with lib;
     port = mkOption {
       type = types.int;
       default = 44986;
-      description = mdDoc ''
+      description = ''
         Port (on 127.0.0.1) to expose finder on.
       '';
     };
@@ -30,7 +30,7 @@ with lib;
     elasticsearchTag = mkOption {
       type = types.str;
       default = "8.0.0";
-      description = mdDoc ''
+      description = ''
         Tag to use of the `elasticsearch` container image.
       '';
     };
@@ -38,7 +38,7 @@ with lib;
     mangaDir = mkOption {
       type = types.path;
       example = "/mnt/nas/manga";
-      description = mdDoc ''
+      description = ''
         Directory to serve manga files from.
       '';
     };

--- a/shared/foundryvtt/options.nix
+++ b/shared/foundryvtt/options.nix
@@ -7,7 +7,7 @@ with lib;
     enable = mkOption {
       type = types.bool;
       default = false;
-      description = mdDoc ''
+      description = ''
         Enable the [FoundryVTT](https://foundryvtt.com/) service.
       '';
     };
@@ -15,7 +15,7 @@ with lib;
     port = mkOption {
       type = types.int;
       default = 46885;
-      description = mdDoc ''
+      description = ''
         Port (on 127.0.0.1) to expose FoundryVTT on.
       '';
     };
@@ -23,7 +23,7 @@ with lib;
     dataDir = mkOption {
       type = types.str;
       default = "/var/lib/foundryvtt";
-      description = mdDoc ''
+      description = ''
         Directory to store data files in.
 
         The downloaded FoundryVTT program files must be in `''${dataDir}/bin`.

--- a/shared/minecraft/options.nix
+++ b/shared/minecraft/options.nix
@@ -7,7 +7,7 @@ with lib;
     enable = mkOption {
       type = types.bool;
       default = false;
-      description = mdDoc ''
+      description = ''
         Enable the [Minecraft](https://www.minecraft.net/en-us) service.
       '';
     };
@@ -15,7 +15,7 @@ with lib;
     dataDir = mkOption {
       type = types.path;
       default = "/var/lib/minecraft";
-      description = mdDoc ''
+      description = ''
         Directory to store data files in.
 
         If the `erase-your-darlings` module is enabled, this is overridden to be
@@ -30,14 +30,14 @@ with lib;
             autoStart = mkOption {
               type = types.bool;
               default = true;
-              description = mdDoc ''
+              description = ''
                 Start the server automatically on boot.
               '';
             };
 
             port = mkOption {
               type = types.int;
-              description = mdDoc ''
+              description = ''
                 Port to open in the firewall.  This must match the port in the
                 `server.properties` file.
               '';
@@ -46,7 +46,7 @@ with lib;
             jar = mkOption {
               type = types.str;
               default = "minecraft-server.jar";
-              description = mdDoc ''
+              description = ''
                 Name of the JAR file to use.  This file must be in the working
                 directory.
               '';
@@ -55,7 +55,7 @@ with lib;
             jre = mkOption {
               type = types.package;
               default = pkgs.jdk17_headless;
-              description = mdDoc ''
+              description = ''
                 Java runtime package to use.
               '';
             };
@@ -63,7 +63,7 @@ with lib;
             jvmOpts = mkOption {
               type = types.separatedString " ";
               default = "-Xmx4G -Xms4G -XX:+UnlockExperimentalVMOptions -XX:+UseG1GC -XX:G1NewSizePercent=20 -XX:G1ReservePercent=20 -XX:MaxGCPauseMillis=50 -XX:G1HeapRegionSize=32M";
-              description = mdDoc ''
+              description = ''
                 Java runtime arguments.  Cargo cult these from a forum post and
                 then never think about them again.
               '';
@@ -72,7 +72,7 @@ with lib;
         }
       );
       default = { };
-      description = mdDoc ''
+      description = ''
         Attrset of minecraft server definitions.  Each server `{name}` is run in
         the working directory `''${dataDir}/{name}`.
       '';

--- a/shared/oci-containers/options.nix
+++ b/shared/oci-containers/options.nix
@@ -5,14 +5,14 @@ let
   portOptions = {
     host = mkOption {
       type = types.int;
-      description = mdDoc ''
+      description = ''
         Host port (on 127.0.0.1) to expose the container port on.
       '';
     };
 
     inner = mkOption {
       type = types.int;
-      description = mdDoc ''
+      description = ''
         The container port to expose to the hosti.
       '';
     };
@@ -22,7 +22,7 @@ let
     name = mkOption {
       type = types.nullOr types.str;
       default = null;
-      description = mdDoc ''
+      description = ''
         Name of the volume.  This is equivalent to:
 
         ```nix
@@ -36,7 +36,7 @@ let
     host = mkOption {
       type = types.nullOr types.str;
       default = null;
-      description = mdDoc ''
+      description = ''
         Directory on the host to bind-mount into the container.
 
         This option conflicts with `''${name}`.
@@ -45,7 +45,7 @@ let
 
     inner = mkOption {
       type = types.str;
-      description = mdDoc ''
+      description = ''
         Directory in the container to mount the volume to.
       '';
     };
@@ -56,7 +56,7 @@ let
     autoStart = mkOption {
       type = types.bool;
       default = true;
-      description = mdDoc ''
+      description = ''
         Start the container automatically on boot.
       '';
     };
@@ -64,7 +64,7 @@ let
     cmd = mkOption {
       type = types.listOf types.str;
       default = [ ];
-      description = mdDoc ''
+      description = ''
         Command-line arguments to pass to the container image's entrypoint.
       '';
     };
@@ -73,7 +73,7 @@ let
       type = types.listOf types.str;
       default = [ ];
       example = [ "concourse-db" ];
-      description = mdDoc ''
+      description = ''
         Other containers that this one depends on, in `''${pod}-''${name}`
         format.
       '';
@@ -82,7 +82,7 @@ let
     environment = mkOption {
       type = types.attrsOf types.str;
       default = { };
-      description = mdDoc ''
+      description = ''
         Environment variables to set for this container.
       '';
     };
@@ -90,7 +90,7 @@ let
     environmentFiles = mkOption {
       type = types.listOf types.path;
       default = [ ];
-      description = mdDoc ''
+      description = ''
         List of environment files for this container.
       '';
     };
@@ -98,14 +98,14 @@ let
     extraOptions = mkOption {
       type = types.listOf types.str;
       default = [ ];
-      description = mdDoc ''
+      description = ''
         Extra options to pass to `docker run` / `podman run`.
       '';
     };
 
     image = mkOption {
       type = types.str;
-      description = mdDoc ''
+      description = ''
         Container image to run.
       '';
     };
@@ -114,21 +114,21 @@ let
       username = mkOption {
         type = types.nullOr types.str;
         default = null;
-        description = mdDoc ''
+        description = ''
           Username for the container registry.
         '';
       };
       passwordFile = mkOption {
         type = types.nullOr types.str;
         default = null;
-        description = mdDoc ''
+        description = ''
           File containing the password for the container registry.
         '';
       };
       registry = mkOption {
         type = types.nullOr types.str;
         default = null;
-        description = mdDoc ''
+        description = ''
           Container registry to authenticate with.
         '';
       };
@@ -138,7 +138,7 @@ let
     ports = mkOption {
       type = types.listOf (types.submodule { options = portOptions; });
       default = [ ];
-      description = mdDoc ''
+      description = ''
         List of ports to expose.
       '';
     };
@@ -146,7 +146,7 @@ let
     volumes = mkOption {
       type = types.listOf (types.submodule { options = volumeOptions; });
       default = [ ];
-      description = mdDoc ''
+      description = ''
         List of volume definitions.
       '';
     };
@@ -155,7 +155,7 @@ let
     pullOnStart = mkOption {
       type = types.bool;
       default = true;
-      description = mdDoc ''
+      description = ''
         Pull the container image when starting (useful for `:latest` images).
       '';
     };
@@ -166,7 +166,7 @@ in
     backend = mkOption {
       type = types.enum [ "docker" "podman" ];
       default = "docker";
-      description = mdDoc ''
+      description = ''
         The container runtime.
       '';
     };
@@ -177,14 +177,14 @@ in
           containers = mkOption {
             type = types.attrsOf (types.submodule { options = containerOptions; });
             default = { };
-            description = mdDoc ''
+            description = ''
               Attrset of container definitions.
             '';
           };
           volumeSubDir = mkOption {
             type = types.str;
             default = name;
-            description = mdDoc ''
+            description = ''
               Subdirectory of the `''${volumeBaseDir}` to store bind-mounts
               under.
             '';
@@ -192,14 +192,14 @@ in
         };
       }));
       default = { };
-      description = mdDoc ''
+      description = ''
         Attrset of pod definitions.
       '';
     };
 
     volumeBaseDir = mkOption {
       type = types.str;
-      description = mdDoc ''
+      description = ''
         Directory to store volume bind-mounts under.
 
         If the `erase-your-darlings` module is enabled, this is overridden to be

--- a/shared/options.nix
+++ b/shared/options.nix
@@ -7,7 +7,7 @@ with lib;
     ipBlocklistFile = mkOption {
       type = types.nullOr types.str;
       default = null;
-      description = mdDoc ''
+      description = ''
         File containing IPs to block.  This is of the form:
 
         ```text

--- a/shared/pleroma/options.nix
+++ b/shared/pleroma/options.nix
@@ -7,7 +7,7 @@ with lib;
     enable = mkOption {
       type = types.bool;
       default = false;
-      description = mdDoc ''
+      description = ''
         Enable the [Pleroma](https://pleroma.social/) service.
       '';
     };
@@ -15,7 +15,7 @@ with lib;
     port = mkOption {
       type = types.int;
       default = 46283;
-      description = mdDoc ''
+      description = ''
         Port (on 127.0.0.1) to expose Pleroma on.
       '';
     };
@@ -23,7 +23,7 @@ with lib;
     postgresTag = mkOption {
       type = types.str;
       default = "16";
-      description = mdDoc ''
+      description = ''
         Tag to use of the `postgres` container image.
       '';
     };
@@ -31,7 +31,7 @@ with lib;
     domain = mkOption {
       type = types.str;
       example = "social.lainon.life";
-      description = mdDoc ''
+      description = ''
         Domain which Pleroma will be exposed on.
       '';
     };
@@ -39,7 +39,7 @@ with lib;
     faviconPath = mkOption {
       type = types.nullOr types.path;
       default = null;
-      description = mdDoc ''
+      description = ''
         File to use for the favicon.
       '';
     };
@@ -47,7 +47,7 @@ with lib;
     instanceName = mkOption {
       type = types.nullOr types.str;
       default = null;
-      description = mdDoc ''
+      description = ''
         Name of the instance, defaults to the `''${domain}` if not set.
       '';
     };
@@ -55,7 +55,7 @@ with lib;
     adminEmail = mkOption {
       type = types.str;
       default = "mike@barrucadu.co.uk";
-      description = mdDoc ''
+      description = ''
         Email address used to contact the server operator.
       '';
     };
@@ -63,7 +63,7 @@ with lib;
     notifyEmail = mkOption {
       type = types.nullOr types.str;
       default = null;
-      description = mdDoc ''
+      description = ''
         Email address used for notification, defaults to the `''${adminEmail}`
         if not set.
       '';
@@ -72,14 +72,14 @@ with lib;
     allowRegistration = mkOption {
       type = types.bool;
       default = false;
-      description = mdDoc ''
+      description = ''
         Allow new users to sign up.
       '';
     };
 
     secretsFile = mkOption {
       type = types.str;
-      description = mdDoc ''
+      description = ''
         File containing secret configuration.
 
         See the Pleroma documentation for what this needs to contain.

--- a/shared/resolved/options.nix
+++ b/shared/resolved/options.nix
@@ -7,7 +7,7 @@ with lib;
     enable = mkOption {
       type = types.bool;
       default = false;
-      description = mdDoc ''
+      description = ''
         Enable the [resolved](https://github.com/barrucadu/resolved) service.
       '';
     };
@@ -15,7 +15,7 @@ with lib;
     address = mkOption {
       type = types.str;
       default = "0.0.0.0:53";
-      description = mdDoc ''
+      description = ''
         Address to listen on.
       '';
     };
@@ -23,7 +23,7 @@ with lib;
     metricsAddress = mkOption {
       type = types.str;
       default = "127.0.0.1:9420";
-      description = mdDoc ''
+      description = ''
         Address to listen on to serve Prometheus metrics.
       '';
     };
@@ -31,7 +31,7 @@ with lib;
     authoritativeOnly = mkOption {
       type = types.bool;
       default = false;
-      description = mdDoc ''
+      description = ''
         Only answer queries for which this server is authoritative: do not
         perform recursive or forwarding resolution.
       '';
@@ -40,7 +40,7 @@ with lib;
     protocolMode = mkOption {
       type = types.str;
       default = "only-v4";
-      description = mdDoc ''
+      description = ''
         How to choose between connecting to upstream nameservers over IPv4 or
         IPv6 when acting as a recursive resolver.
       '';
@@ -49,7 +49,7 @@ with lib;
     forwardAddress = mkOption {
       type = types.nullOr types.str;
       default = null;
-      description = mdDoc ''
+      description = ''
         Act as a forwarding resolver, not a recursive resolver: forward queries
         which can't be answered from local state to this nameserver and cache
         the result.
@@ -59,7 +59,7 @@ with lib;
     cacheSize = mkOption {
       type = types.int;
       default = 512;
-      description = mdDoc ''
+      description = ''
         How many records to hold in the cache.
       '';
     };
@@ -67,7 +67,7 @@ with lib;
     hostsDirs = mkOption {
       type = types.listOf types.str;
       default = [ ];
-      description = mdDoc ''
+      description = ''
         List of directories to read hosts files from.
       '';
     };
@@ -75,7 +75,7 @@ with lib;
     zonesDirs = mkOption {
       type = types.listOf types.str;
       default = [ ];
-      description = mdDoc ''
+      description = ''
         List of directories to read zone files from.
       '';
     };
@@ -83,7 +83,7 @@ with lib;
     useDefaultZones = mkOption {
       type = types.bool;
       default = true;
-      description = mdDoc ''
+      description = ''
         Include the default zone files.
       '';
     };
@@ -91,7 +91,7 @@ with lib;
     logLevel = mkOption {
       type = types.str;
       default = "dns_resolver=info,resolved=info";
-      description = mdDoc ''
+      description = ''
         Verbosity of the log messages.
       '';
     };
@@ -99,7 +99,7 @@ with lib;
     logFormat = mkOption {
       type = types.str;
       default = "json,no-time";
-      description = mdDoc ''
+      description = ''
         Format of the log messages.
       '';
     };

--- a/shared/restic-backups/options.nix
+++ b/shared/restic-backups/options.nix
@@ -7,7 +7,7 @@ let
     paths = mkOption {
       type = types.listOf types.str;
       default = [ ];
-      description = mdDoc ''
+      description = ''
         List of paths to back up.
       '';
     };
@@ -15,7 +15,7 @@ let
     prepareCommand = mkOption {
       type = types.nullOr types.str;
       default = null;
-      description = mdDoc ''
+      description = ''
         A script to run before beginning the backup.
       '';
     };
@@ -23,7 +23,7 @@ let
     cleanupCommand = mkOption {
       type = types.nullOr types.str;
       default = null;
-      description = mdDoc ''
+      description = ''
         A script to run after taking the backup.
       '';
     };
@@ -31,7 +31,7 @@ let
     startAt = mkOption {
       type = types.str;
       default = "Mon, 04:00";
-      description = mdDoc ''
+      description = ''
         When to run the backup.
       '';
     };
@@ -40,7 +40,7 @@ let
   sudoRuleOptions = {
     command = mkOption {
       type = types.str;
-      description = mdDoc ''
+      description = ''
         The command for which the rule applies.
       '';
     };
@@ -48,7 +48,7 @@ let
     runAs = mkOption {
       type = types.str;
       default = "ALL:ALL";
-      description = mdDoc ''
+      description = ''
         The user / group under which the command is allowed to run.
 
         A user can be specified using just the username: `"foo"`. It is also
@@ -63,7 +63,7 @@ in
     enable = mkOption {
       type = types.bool;
       default = false;
-      description = mdDoc ''
+      description = ''
         Enable the backup service.
       '';
     };
@@ -71,14 +71,14 @@ in
     backups = mkOption {
       type = types.attrsOf (types.submodule { options = backupOptions; });
       default = { };
-      description = mdDoc ''
+      description = ''
         Attrset of backup job definitions.
       '';
     };
 
     environmentFile = mkOption {
       type = types.nullOr types.str;
-      description = mdDoc ''
+      description = ''
         Environment file to pass secrets into the service.  This is of the form:
 
         ```text
@@ -103,7 +103,7 @@ in
     sudoRules = mkOption {
       type = types.listOf (types.submodule { options = sudoRuleOptions; });
       default = [ ];
-      description = mdDoc ''
+      description = ''
         List of additional sudo rules to grant the backup user.
       '';
     };
@@ -111,7 +111,7 @@ in
     checkRepositoryAt = mkOption {
       type = types.nullOr types.str;
       default = null;
-      description = mdDoc ''
+      description = ''
         If not null, when to run `restic check` to validate the repository
         metadata.
       '';

--- a/shared/torrents/options.nix
+++ b/shared/torrents/options.nix
@@ -7,7 +7,7 @@ with lib;
     enable = mkOption {
       type = types.bool;
       default = false;
-      description = mdDoc ''
+      description = ''
         Enable the [Transmission](https://transmissionbt.com/) service.
       '';
     };
@@ -15,7 +15,7 @@ with lib;
     downloadDir = mkOption {
       type = types.str;
       example = "/mnt/nas/torrents/files";
-      description = mdDoc ''
+      description = ''
         Directory to download torrented files to.
       '';
     };
@@ -23,7 +23,7 @@ with lib;
     stateDir = mkOption {
       type = types.str;
       example = "/var/lib/torrents";
-      description = mdDoc ''
+      description = ''
         Directory to store service state in.
       '';
     };
@@ -31,21 +31,21 @@ with lib;
     watchDir = mkOption {
       type = types.str;
       example = "/mnt/nas/torrents/watch";
-      description = mdDoc ''
+      description = ''
         Directory to monitor for new .torrent files.
       '';
     };
 
     user = mkOption {
       type = types.str;
-      description = mdDoc ''
+      description = ''
         The user to run Transmission as.
       '';
     };
 
     group = mkOption {
       type = types.str;
-      description = mdDoc ''
+      description = ''
         The group to run Transmission as.
       '';
     };
@@ -53,7 +53,7 @@ with lib;
     logLevel = mkOption {
       type = types.ints.between 0 6;
       default = 2;
-      description = mdDoc ''
+      description = ''
         Verbosity of the log messages.
       '';
     };
@@ -61,7 +61,7 @@ with lib;
     openFirewall = mkOption {
       type = types.bool;
       default = true;
-      description = mdDoc ''
+      description = ''
         Allow connections from TCP and UDP ports `''${portRange.from}` to
         `''${portRange.to}`.
       '';
@@ -70,7 +70,7 @@ with lib;
     peerPort = mkOption {
       type = types.port;
       default = 50000;
-      description = mdDoc ''
+      description = ''
         Port to accept peer connections on.
       '';
     };
@@ -78,7 +78,7 @@ with lib;
     rpcPort = mkOption {
       type = types.port;
       default = 49528;
-      description = mdDoc ''
+      description = ''
         Port to accept RPC connections on.  Bound on 127.0.0.1.
       '';
     };

--- a/shared/umami/options.nix
+++ b/shared/umami/options.nix
@@ -7,7 +7,7 @@ with lib;
     enable = mkOption {
       type = types.bool;
       default = false;
-      description = mdDoc ''
+      description = ''
         Enable the [umami](https://umami.is/) service.
       '';
     };
@@ -15,7 +15,7 @@ with lib;
     port = mkOption {
       type = types.int;
       default = 46489;
-      description = mdDoc ''
+      description = ''
         Port (on 127.0.0.1) to expose umami on.
       '';
     };
@@ -23,7 +23,7 @@ with lib;
     postgresTag = mkOption {
       type = types.str;
       default = "16";
-      description = mdDoc ''
+      description = ''
         Tag to use of the `postgres` container image.
       '';
     };
@@ -31,14 +31,14 @@ with lib;
     umamiTag = mkOption {
       type = types.str;
       default = "postgresql-v2.9.0";
-      description = mdDoc ''
+      description = ''
         Tag to use of the `ghcr.io/umami-software/umami` container image.
       '';
     };
 
     environmentFile = mkOption {
       type = types.str;
-      description = mdDoc ''
+      description = ''
         Environment file to pass secrets into the service.  This is of the form:
 
         ```text


### PR DESCRIPTION
Documentation is markdown by default now.