### PR TITLE
Upgrade elasticsearch to 8.18.2 

### DIFF
--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -18,4 +18,5 @@
 
 - [Set up a new host](./runbooks/set-up-a-new-host.md)
 - [Move a configuration to a new machine](./runbooks/move-a-configuration-to-a-new-machine.md)
+- [Upgrade to a new version of elasticsearch](./runbooks/upgrade-to-a-new-version-of-elasticsearch.md)
 - [Upgrade to a new version of postgres](./runbooks/upgrade-to-a-new-version-of-postgres.md)

--- a/docs/src/runbooks/upgrade-to-a-new-version-of-elasticsearch.md
+++ b/docs/src/runbooks/upgrade-to-a-new-version-of-elasticsearch.md
@@ -1,0 +1,77 @@
+Upgrade to a new version of elasticsearch
+====================================
+
+
+Change the default elasticsearch version for a module
+-----------------------------------------------------
+
+1. Individually upgrade all hosts to the new version, following the processes below.
+2. Change the default value of the `elasticsearchTag` option for the module.
+3. Remove the per-host `elasticsearchTag` options.
+
+
+Upgrade to a new minor version
+------------------------------
+
+This is generally safe.  Just change the `elasticsearchTag` and rebuild the NixOS
+configuration.
+
+
+Upgrade to a new major version
+------------------------------
+
+In brief: take a backup, upgrade to the latest minor release of the current
+major version, fix any application warnings, and then upgrade to the initial
+release of the new major version.
+
+Shell variables:
+
+- `$VOLUME_DIR` - the directory on the host that the container's `/usr/share/elasticsearch/data` is bind-mounted to
+
+1. Upgrade to the latest minor release of the current major version.
+
+    1. Change the `elasticsearchTag` option in the host's NixOS configuration to the latest minor release of the current major version.
+
+    2. Rebuild the NixOS configuration and check that the database and all of its dependent services come back up:
+
+        ```bash
+        sudo nixos-rebuild switch
+        ```
+
+2. Exercise the application, performing both reads and writes: check the elasticsearch log for deprecation warnings, and fix any issues in the application.
+
+3. Stop the database.
+
+4. Take a backup:
+
+    ```bash
+    sudo cp -a "$VOLUME_DIR" "${VOLUME_DIR}.bak"
+    ```
+
+5. Change the `elasticsearchTag` option in the host's NixOS configuration to the initial release of the new major version.
+
+6. Rebuild the NixOS configuration and check that the database and all of its dependent services come back up:
+
+    ```bash
+    sudo nixos-rebuild switch
+    ```
+
+### Rollback
+
+The old database files are still present at `${VOLUME_DIR}.bak`, so:
+
+1. Stop all the relevant services, including the database container.
+
+2. Restore the backup:
+
+    ```bash
+    sudo mv "$VOLUME_DIR" "${VOLUME_DIR}.aborted"
+    sudo mv "${VOLUME_DIR}.bak" "$VOLUME_DIR"
+    ```
+
+3. If the `elasticsearchTag` has been updated in the NixOS configuration:
+
+    1. Revert it to its previous version.
+    2. Rebuild the NixOS configuration.
+
+4. Restart all the relevant services.

--- a/shared/bookdb/options.nix
+++ b/shared/bookdb/options.nix
@@ -30,7 +30,7 @@ with lib;
 
     elasticsearchTag = mkOption {
       type = types.str;
-      default = "8.0.0";
+      default = "8.18.2";
       description = ''
         Tag to use of the `elasticsearch` container image.
       '';

--- a/shared/bookmarks/options.nix
+++ b/shared/bookmarks/options.nix
@@ -30,7 +30,7 @@ with lib;
 
     elasticsearchTag = mkOption {
       type = types.str;
-      default = "8.0.0";
+      default = "8.18.2";
       description = ''
         Tag to use of the `elasticsearch` container image.
       '';

--- a/shared/finder/options.nix
+++ b/shared/finder/options.nix
@@ -29,7 +29,7 @@ with lib;
 
     elasticsearchTag = mkOption {
       type = types.str;
-      default = "8.0.0";
+      default = "8.18.2";
       description = ''
         Tag to use of the `elasticsearch` container image.
       '';


### PR DESCRIPTION
This is the latest minor version in the 8.x series, preparation for upgrading to 9.0.0.