### PR TITLE
Add `mtr` to default packages

### DIFF
--- a/shared/default.nix
+++ b/shared/default.nix
@@ -343,6 +343,7 @@ in
       lsof
       lynx
       man-pages
+      mtr
       ncdu
       psmisc
       python3


### PR DESCRIPTION
Very handy for diagnosing network issues.