### PR TITLE
Bump flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -13,11 +13,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1752441925,
-        "narHash": "sha256-tIn8wmeefylG2GtmbZo5s/yZyw5I48rHPmgWn3Q0aQk=",
+        "lastModified": 1758918553,
+        "narHash": "sha256-hD49F+VN31lsnDUKgJa/hoJJeJE5isb2bPk2tH03oqs=",
         "owner": "barrucadu",
         "repo": "bookdb",
-        "rev": "0852ebc4fd40603596cace3f6c3893010206f572",
+        "rev": "fbf436b8ac1ec64a85b08273f87ffe93dd36cdc1",
         "type": "github"
       },
       "original": {
@@ -39,11 +39,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1752440903,
-        "narHash": "sha256-pMGQKzkB374+Cm2Ed+2ZPPLUNHcUpZvbKUuTFrndviM=",
+        "lastModified": 1758917988,
+        "narHash": "sha256-q5CSf0M4GdvJypdoTRFxlOje+Sb3Cdd/rEUnmKqi3ss=",
         "owner": "barrucadu",
         "repo": "bookmarks",
-        "rev": "5d29814968ccc71a66f4613409c6f634697f7ad7",
+        "rev": "b9ef27e47c48763501cba6f159ef357f37a68f99",
         "type": "github"
       },
       "original": {
@@ -74,11 +74,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1753345091,
-        "narHash": "sha256-CdX2Rtvp5I8HGu9swBmYuq+ILwRxpXdJwlpg8jvN4tU=",
+        "lastModified": 1758791193,
+        "narHash": "sha256-F8WmEwFoHsnix7rt290R0rFXNJiMbClMZyIC/e+HYf0=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "3ff0e34b1383648053bba8ed03f201d3466f90c9",
+        "rev": "25e53aa156d47bad5082ff7618f5feb1f5e02d01",
         "type": "github"
       },
       "original": {
@@ -124,11 +124,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1753177777,
-        "narHash": "sha256-+skiz5mR73jq/ybBq5oWEDG/eUDg9aVVJLpHPOmt1+M=",
+        "lastModified": 1758669941,
+        "narHash": "sha256-1jgHdZYyu9NsDyk5hLevwqe6enPyfeGdNZtpC0wmL+I=",
         "owner": "barrucadu",
         "repo": "resolved",
-        "rev": "4ce5a4b2771e9f43e2702496c4abe01fa5342c2b",
+        "rev": "65de91aad874d82e725fa7abad494afea00e8e4b",
         "type": "github"
       },
       "original": {
@@ -156,11 +156,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1753497720,
-        "narHash": "sha256-yzZkDMVfPpNyTciQOfriWpRXrgGNT/cvrFAEQZ//SZs=",
+        "lastModified": 1758854041,
+        "narHash": "sha256-kZ+24pbf4FiHlYlcvts64BhpxpHkPKIQXBmx1OmBAIo=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "c8b8b812010515b7d9bd7e538f06a9f4edb373ff",
+        "rev": "02227ca8c229c968dbb5de95584cfb12b4313104",
         "type": "github"
       },
       "original": {
@@ -176,11 +176,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1752544651,
-        "narHash": "sha256-GllP7cmQu7zLZTs9z0J2gIL42IZHa9CBEXwBY9szT0U=",
+        "lastModified": 1758425756,
+        "narHash": "sha256-L3N8zV6wsViXiD8i3WFyrvjDdz76g3tXKEdZ4FkgQ+Y=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "2c8def626f54708a9c38a5861866660395bb3461",
+        "rev": "e0fdaea3c31646e252a60b42d0ed8eafdb289762",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
This made some change to the`virtualisation.oci-containers.*.dependsOn`, so the non-container dependencies are now attached to the systemd unit directly.