### PR TITLE
Upgrade to nixos-26.05

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -13,11 +13,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1777948710,
-        "narHash": "sha256-wgId+Ra8q5GMuGDLuy/5cXpgeX9+p/dhrW2Bnh6J6ec=",
+        "lastModified": 1779437482,
+        "narHash": "sha256-M5YqVVTUK/jhNkQLF6KkhLlkMy4QsxOhFSkLFuBaiI4=",
         "owner": "barrucadu",
         "repo": "bookdb",
-        "rev": "b856c11a1893ae9d4aaef5990c07f9e83f0ac150",
+        "rev": "03b01dcf486234ab1f7a7d2d130337b9999cb639",
         "type": "github"
       },
       "original": {
@@ -39,11 +39,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1777940660,
-        "narHash": "sha256-R0X269V+FK0c4jDqSKd3JNPVVcOqoQx2k2G8i2A01EM=",
+        "lastModified": 1779762105,
+        "narHash": "sha256-NuDFNzxtOt07NgWbF7+MbPriNLqKYXJJktZBFAXGUew=",
         "owner": "barrucadu",
         "repo": "bookmarks",
-        "rev": "7d1654b64d64b0e8c5744bcccb3dd20ac3ac4aa8",
+        "rev": "b00426d231bb0fc0f554c9e4a73586217d06c282",
         "type": "github"
       },
       "original": {
@@ -74,16 +74,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1777933422,
-        "narHash": "sha256-WpfZLatstZKZV43HtpK4cbEdQZvHhwVRVtW/rc6YTRU=",
+        "lastModified": 1781176983,
+        "narHash": "sha256-m9YiA+7R78L1018qaHY3zkGUTDy7SUej5wuZoxxUqCU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "41a7bd591bc47320390c829b9f16bfc59b25843c",
+        "rev": "88a9d48c8af83291a3d1d33ab0955d276accf6f1",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-25.11-small",
+        "ref": "nixos-26.05-small",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -124,11 +124,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1777971516,
-        "narHash": "sha256-qI5htamsKZ+/ACDB1mksxVAMKEIe1w0+AG4TSHrdyVs=",
+        "lastModified": 1780649304,
+        "narHash": "sha256-3BSLeSUfc2Z9yQ/s4U0hc7DFepytnUYGUuEbJGCO0g0=",
         "owner": "barrucadu",
         "repo": "resolved",
-        "rev": "8a201e7345928c61870c4cf253eeb7aa822bbc76",
+        "rev": "e931e1efd725ecf6644a430ad6b8627f7fc3d97f",
         "type": "github"
       },
       "original": {
@@ -156,11 +156,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1777950921,
-        "narHash": "sha256-NpOgt8ISaHTDNJZjNUfwFfbieKfRXzab4WKM31gZCGA=",
+        "lastModified": 1781147846,
+        "narHash": "sha256-hBdiQYd40xRtBWBiXHUxuQYWmJBiK19YO1FiYgrmEo0=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "366ea19e0e55b768f74b7a0b2a20f847e7ae828d",
+        "rev": "107c334f141854f563f8adf1db781dc453d92639",
         "type": "github"
       },
       "original": {
@@ -176,11 +176,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1777944972,
-        "narHash": "sha256-VfGRo1qTBKOe3s2gOv8LSoA6Fk19PvBlwQ1ECN0Evn8=",
+        "lastModified": 1780547341,
+        "narHash": "sha256-Gq8KNx5A7hBB3uGJaj6eQfLDIz5YdLu92gqBcvHvoUo=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "c591bf665727040c6cc5cb409079acb22dcce33c",
+        "rev": "9ed65852b6257fbeae4355bc24ecfea307ca759a",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -1,6 +1,6 @@
 {
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.11-small";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-26.05-small";
     sops-nix = {
       url = "github:Mic92/sops-nix";
       inputs.nixpkgs.follows = "nixpkgs";

--- a/hosts/nyarlathotep/configuration.nix
+++ b/hosts/nyarlathotep/configuration.nix
@@ -364,7 +364,11 @@ in
   sops.secrets."services/alertmanager/env" = { };
 
   services.grafana = {
-    settings.server.root_url = "http://grafana.nyarlathotep.lan";
+    settings = {
+      server.root_url = "http://grafana.nyarlathotep.lan";
+      security.admin_password = "$__file{${config.sops.secrets."services/grafana/admin_password".path}}";
+      security.secret_key = "$__file{${config.sops.secrets."services/grafana/secret_key".path}}";
+    };
     provision = {
       datasources.settings.datasources = [
         {
@@ -383,6 +387,8 @@ in
         ];
     };
   };
+  sops.secrets."services/grafana/admin_password".owner = config.users.users.grafana.name;
+  sops.secrets."services/grafana/secret_key".owner = config.users.users.grafana.name;
 
   services.prometheus.webExternalUrl = "http://prometheus.nyarlathotep.lan";
   services.prometheus.scrapeConfigs = [

--- a/hosts/nyarlathotep/secrets.yaml
+++ b/hosts/nyarlathotep/secrets.yaml
@@ -11,14 +11,12 @@ nixfiles:
 services:
     alertmanager:
         env: ENC[AES256_GCM,data:O3XHFKP9NRSfRuLOg0cF+g2knAYyAMoc1s+fJ3/eikOxGyqPlKehlJhjh+lfW5Em7VUjwLVZLjsR0Hq+zvx9oHFGiBX8wxWhYMajMjzE9yfyAghmiIX5LL1T9Wgz+TBS4IJw0uEU,iv:/LyaBKRMHcAn8wQTwj6ZQBR17pnNdIanHi4CWLSfENs=,tag:FVjC/MEci9B4hWA5Ev3+Yw==,type:str]
+    grafana:
+        admin_password: ENC[AES256_GCM,data:+YfYJo0b7jbZSjC528m/HnI82F0MC4l7QhnB4cRCeeg=,iv:aIRkIR54zRnzaDyfuKjB/QZoKqCo8NClQ1XswUOqktc=,tag:+XakJdQj3KCd8fpbC5jIrA==,type:str]
+        secret_key: ENC[AES256_GCM,data:2p2Bf/s0kQsyI2c0GhylH0N/ISG36U+958YDgkHjE3A=,iv:XARnvLSlDXtKvIJrGAv3ldyTe9kL8Lo1Bzy+mg+0jMU=,tag:RGpAZGa9hJeV0I97qhXjRw==,type:str]
 sops:
-    kms: []
-    gcp_kms: []
-    azure_kv: []
-    hc_vault: []
     age:
-        - recipient: age1sdnp5uxhdtujc78penv2gntnenzcfju7est4hslz6eqgfk26u9nskkk634
-          enc: |
+        - enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
             YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAzbWpwbzYvQnJaR3B4L0Zk
             WlJna2xXTzZ3TXAyVktXRTNGV2EvR3V6S25nCi9ITmROQ3owcGlIZlNDVTZDU3h6
@@ -26,8 +24,8 @@ sops:
             SFkyTXBscUZjYVhEVENWZkU5d283KzQKXd6VX+ZetGZuKIBZd88zk6IRLLeydXbD
             +jF2ojL15sO2EIB4c576Y9xdRgC6GFNHXbUM2j5ghoII05bvr0C31g==
             -----END AGE ENCRYPTED FILE-----
-        - recipient: age1700sgwfejx38fh66k6sajxe507w9x6ptcxfh4dmyffflml75w4fqmteyfy
-          enc: |
+          recipient: age1sdnp5uxhdtujc78penv2gntnenzcfju7est4hslz6eqgfk26u9nskkk634
+        - enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
             YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBDMlY0RlJRMjR2U0M2R3R0
             Nnh2ZzhRamUxdjEyZEFmQ1g4akNLbG1JUWdFClZ4ZlJzKzJub1VtOUN3eE5SaWhI
@@ -35,8 +33,8 @@ sops:
             UFVZQkpPSUY1YWZlRlFCbDNBcHhzVmcKzBqO5fMoaNerJw3ovWXCPLQM0cDfte03
             ZiXMnrIUfIf2AntjjnZKc84jsnubTyD2fQLGNVkAetmQ3PTb3OKXqQ==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2024-09-02T19:42:11Z"
-    mac: ENC[AES256_GCM,data:Fvlv7VdlVJotJtwoRUTbif2Hu/ly9P7sHB3S39Q5h4JJuX19jO32VySS5dg0NKzm9VbjaD42E+5wGty128JQNs4vcS+znlgP1H5ZJdLd0tKTYtGjIdV8CoJAWRdLqcyJwNrGbnEaPkyk5jaIf7m2zTHOIhBrH0nT80QEaqpL0aQ=,iv:Ly3hnnpActejElcp1ubHa9wuMrrFEgHzof07Om9pr5g=,tag:EZm3A4pGldvT+spk45LWxA==,type:str]
-    pgp: []
+          recipient: age1700sgwfejx38fh66k6sajxe507w9x6ptcxfh4dmyffflml75w4fqmteyfy
+    lastmodified: "2026-06-11T22:29:11Z"
+    mac: ENC[AES256_GCM,data:MPzi0HxNQmYcCjMyvBUBhIJgBY5QxEicfRfnbPsJ66Lp0o9G9oApKbVHBfYZPdnRN+uwkKgH+Gr8udIffqen9c2fzUAyWzKBQeuiulWkOnh306LLvhWxaNGIbCU4FGWXJnhiCUXmrUTdC64vCwypnSn5w4cwggUVtT3oLWa8J4o=,iv:HN5SWfwUCa02Gtq3FFjMURtcbXSKbTcQT+hX8MxuGp8=,tag:JXWJRXgY1Os0DHm5wvK+Fw==,type:str]
     unencrypted_suffix: _unencrypted
-    version: 3.8.1
+    version: 3.13.1

--- a/hosts/yuggoth/configuration.nix
+++ b/hosts/yuggoth/configuration.nix
@@ -33,6 +33,8 @@ with lib;
   nixfiles.eraseYourDarlings.barrucaduPasswordFile = config.sops.secrets."users/barrucadu".path;
   sops.secrets."users/barrucadu".neededForUsers = true;
 
+  services.grafana.enable = mkForce false;
+
   ###############################################################################
   ## Website Mirror
   ###############################################################################

--- a/shared/default.nix
+++ b/shared/default.nix
@@ -128,6 +128,10 @@ in
     ## ZFS
     #############################################################################
 
+    # Do not force-import the root pool, if importing root fails add
+    # `zfs_force=1` to the kernel command line
+    boot.zfs.forceImportRoot = false;
+
     # Auto-trim is enabled per-pool:
     # run `sudo zpool set autotrim=on <pool>`
     services.zfs.trim.enable = thereAreZfsFilesystems;

--- a/shared/erase-your-darlings/default.nix
+++ b/shared/erase-your-darlings/default.nix
@@ -9,7 +9,7 @@
 #
 # ["erase your darlings"]: https://grahamc.com/blog/erase-your-darlings/
 # ["set up a new host"]: ./runbooks/set-up-a-new-host.md
-{ config, lib, ... }:
+{ config, pkgs, lib, ... }:
 
 with lib;
 
@@ -23,9 +23,17 @@ in
 
   config = mkIf cfg.enable {
     # Wipe / on boot
-    boot.initrd.postResumeCommands = mkAfter ''
-      zfs rollback -r ${cfg.rootSnapshot}
-    '';
+    boot.initrd.systemd.services.zfs-rollback-root = {
+      wantedBy = ["initrd.target"];
+      after = ["zfs-import.target"];
+      before = ["sysroot.mount"];
+      path = [ pkgs.zfs ];
+      unitConfig.DefaultDependencies = "no";
+      serviceConfig.Type = "oneshot";
+      script = ''
+        zfs rollback -r ${cfg.rootSnapshot}
+      '';
+    };
 
     # Set /etc/machine-id, so that journalctl can access logs from
     # previous boots.


### PR DESCRIPTION
Required changes:

- grafana no longer has a default secret_key and must be set explicitly
- force-importing the ZFS root pool is deprecated and will default to off in 26.11, so turn it off now
- postResumeCommands are now done via systemd units in the initrd

Testing:

- [x] nyarlathotep
- [x] carcosa
- [x] yuggoth