### PR TITLE
Keep only 1 forgejo backup

### DIFF
--- a/shared/forgejo/default.nix
+++ b/shared/forgejo/default.nix
@@ -40,6 +40,8 @@ in
       dump = {
         enable = true;
         type = "tar.xz";
+        age = "1d";
+        interval = "02:00";
       };
       settings = {
         actions = {


### PR DESCRIPTION
Also move the snapshot to before the Monday backup script run so it's immediately copied to Backblaze.  I don't need multiple local backups.