### PR TITLE
Lint & format python with `ruff`

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -97,14 +97,14 @@
           '';
 
           fmt = mkApp "fmt" ''
-            PATH=${with pkgs; lib.makeBinPath [ nix git python3Packages.black ]}
+            PATH=${with pkgs; lib.makeBinPath [ nix git ruff ]}
 
             ${pkgs.lib.fileContents ./scripts/fmt.sh}
           '';
 
           lint = mkApp "lint" ''
             # TODO: add nix-linter back when the package is no longer broken
-            PATH=${with pkgs; lib.makeBinPath [ findutils shellcheck git gnugrep python3Packages.flake8 ]}
+            PATH=${with pkgs; lib.makeBinPath [ findutils shellcheck git gnugrep ruff ]}
 
             ${pkgs.lib.fileContents ./scripts/lint.sh}
           '';

--- a/scripts/fmt.sh
+++ b/scripts/fmt.sh
@@ -1,3 +1,3 @@
 nix fmt -- .
 
-black .
+ruff format .

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -6,9 +6,8 @@ set -ex
 # SC2001: use pattern expansion over sed
 find . -name '*.sh' -print0 | xargs -0 -n1 shellcheck -s bash -e SC2001
 
-# E501: line length (if black is happy, I'm happy)
 # E731: assign lambda to a variable
-find . -name '*.py' -print0 | xargs -0 -n1 flake8 --ignore=E501,E731
+ruff check --ignore=E731 .
 
 find . -name options.nix -print0 | while IFS= read -r -d '' filename; do
     if ! grep -q "$filename" flake.nix; then


### PR DESCRIPTION
Replaces `black` & `flake8` while being compatible with both.